### PR TITLE
feat: add browser OAuth login, CLI register, audit templates, and com…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Standalone CLI for the [Cited](https://youcited.com) GEO platform. Built with Py
 ```bash
 pip install -e ".[dev]"      # Install with dev dependencies
 pytest -v                    # Run all tests
-pytest tests/test_auth.py    # Run a single test file
+pytest tests/test_pipeline.py -v  # Pipeline integration tests
 pytest -k test_version_json  # Run a single test by name
 ruff check src/              # Lint
 mypy src/cited_cli/ --ignore-missing-imports  # Type check
@@ -20,7 +20,7 @@ cited --help                 # Run the CLI
 
 ## Architecture
 
-**Entry point:** `src/cited_cli/app.py` — creates the root `typer.Typer`, registers 10 subcommand groups via `app.add_typer()`, defines global flags (`--json`, `--env`, `--profile`, etc.) in the `main_callback`, and stores shared state in `typer.Context.obj`.
+**Entry point:** `src/cited_cli/app.py` — creates the root `typer.Typer`, registers subcommand groups via `app.add_typer()`, plus top-level `login` and `logout` commands (delegating to `do_login`/`do_logout` from `commands/auth.py`). Defines global flags (`--json`, `--env`, `--profile`, etc.) in the `main_callback`, and stores shared state in `typer.Context.obj`.
 
 **Global state flow:** The callback populates `ctx.obj` with `OutputContext`, `ConfigManager`, profile name, and env override. Every command extracts these via a `_get_ctx()` or `_get_client()` helper at the top of each command module.
 
@@ -30,7 +30,21 @@ print_result(data, out, human_formatter=lambda d, c: render_kv("Title", d, c))
 ```
 `print_result` writes `json.dumps(data)` to stdout in JSON mode, or calls the `human_formatter` otherwise. Errors always go to stderr.
 
-**Authentication:** The CLI authenticates by POSTing to `/auth/login` and extracting the JWT from the `advgeo_session` Set-Cookie header (not the response body). Tokens are stored per-environment via OS keychain (`keyring`) with a file fallback (`~/.cited/credentials.json`). The token is sent back to the API as a cookie, not a Bearer header.
+**Authentication:** Top-level `cited login` is the primary entry point (also available as `cited auth login` for backward compat). Both delegate to `do_login()` / `do_logout()` in `commands/auth.py`.
+
+- **Browser login (default):** `cited login` opens the youcited login page in the browser. The CLI starts a temporary localhost HTTP server (`auth/oauth_server.py`) to receive the OAuth callback token. The success page includes a collapsible token-copy section for the paste fallback.
+- **OAuth provider shortcut:** `cited login --provider google|microsoft|github` sends the user directly to that provider.
+- **Password login:** `cited login --email user@example.com` prompts for password (or use `--password` for non-interactive/CI).
+- **Password registration:** `cited register --email ... --name ... --password ...` is a two-step flow:
+  1. `POST /auth/cli-register` — creates the account and sends a verification email; returns `{"message": "..."}` (201, **no token**).
+  2. CLI prompts the user to paste the verification URL from their inbox (e.g. `https://app.youcited.com/complete-registration?token=<43-char-token>`).
+  3. CLI parses the `?token=` query param and calls `POST /auth/cli-verify-email {"token": "..."}`.
+  4. Backend marks email verified and returns `{"token": "<JWT>", "user": {...}}`; JWT is stored; prints "Email verified! Logged in as {email}".
+  - Endpoint constant: `endpoints.CLI_VERIFY_EMAIL = "/auth/cli-verify-email"`.
+  - Tests mock both endpoints and supply the verification URL via `input=` on `runner.invoke`.
+- **Paste fallback:** If the localhost callback times out (firewall, WSL, SSH), the CLI prompts the user to paste the token shown on the browser success page.
+- **Token storage:** Per-environment via OS keychain (`keyring`) with a file fallback (`~/.cited/credentials.json`). The token is sent back to the API as a cookie, not a Bearer header.
+- **TTY detection:** `commands/auth.py` uses `_is_interactive()` (wrapping `sys.stdin.isatty()`) for all TTY checks — tests monkeypatch this helper.
 
 **Agent API auth** uses a separate path: `X-Agent-API-Key` header, configured via `cited config set agent_api_key` or `CITED_AGENT_API_KEY` env var.
 
@@ -39,7 +53,16 @@ print_result(data, out, human_formatter=lambda d, c: render_kv("Title", d, c))
 2. Add endpoint paths to `src/cited_cli/api/endpoints.py`
 3. Register in `app.py` with `app.add_typer(..., name="<name>")`
 
+**Adding a nested command group (sub-subcommands):**
+Create the inner Typer in a separate file, then register it on the parent app — not on the root app. Example: `audit template` lives in `commands/named_audit.py` and is registered in `app.py` as:
+```python
+audit_app.add_typer(named_audit_app, name="template")
+```
+This gives `cited audit template list|get|create|update|delete` while `cited audit start|status|...` remain top-level on `audit_app`. Crucially, the nested registration must happen **before** `app.add_typer(audit_app, ...)` — in practice, put it at the top of the registration block in `app.py`.
+
 **Adding a new command to an existing group:** Add a function decorated with `@<group>_app.command()` in the relevant command file. Follow the `_get_client()` → try/except `CitedAPIError` → `print_result()` pattern.
+
+**Audit template workflow:** The typical flow is create → review → refine → run audit. Auto-generated questions are rarely perfect, so `audit template update` is a common operation. The `--question` flags on `update` **replace all** existing questions (matching the web editor's save behavior). Omit `--question` to keep existing questions unchanged while updating name/description. Backend endpoint: `PUT /named-audits/{id}` with `NamedAuditUpdate` schema.
 
 ## Key Conventions
 
@@ -56,5 +79,120 @@ print_result(data, out, human_formatter=lambda d, c: render_kv("Title", d, c))
 | Name | URL | Default |
 |------|-----|---------|
 | prod | `https://api.youcited.com` | yes |
-| dev | `https://dev.youcited.com` | |
+| dev  | `https://dev.youcited.com` | |
 | local | `http://localhost:8000` | |
+
+## Real API Response Field Names (Critical)
+
+These field names were confirmed against the live dev API on 2026-03-18. Using the wrong names produces silently empty output (no error, just blank table cells). Always check the live response shape before adding new field access.
+
+### `GET /recommendations/{job_id}/result` (used by `recommend insights` + `recommend result`)
+
+```python
+{
+    "question_insights": [
+        {
+            "question_id":   "uuid",      # ← source_id for solution start; NOT "id"
+            "question_text": "...",       # ← description field; NOT "question"
+            "risk_level":    "high",
+            "coverage_score": 0.33,
+        }
+    ],
+    "head_to_head_comparisons": [         # ← key name; NOT "head_to_head"
+        {
+            "competitor_domain": "competitor.com",  # ← source_id; no uuid id field
+            "competitor_url":    "https://...",
+            "business_domain":   "...",
+            "overall_winner":    "business",
+        }
+    ],
+    "strengthening_tips": [
+        {
+            "category": "llms_txt",       # ← source_id for solution start; no uuid id field
+            "title":    "Create llms.txt for AI Discovery",
+            "priority": "high",
+        }
+    ],
+    "priority_actions": [],
+}
+```
+
+### `POST /solutions/request` (used by `solution start`)
+
+```json
+{
+    "recommendation_job_id": "<uuid>",
+    "source_type": "question_insight",
+    "source_id": "<question_id from question_insights>"
+}
+```
+
+**`source_type` enum:** `question_insight` · `head_to_head` · `strengthening_tip` · `priority_action`
+
+This endpoint replaced the deprecated `POST /solutions/create` which took `{"recommendation_id": ...}`.
+
+### `POST /businesses/{id}/crawl` (used by `business crawl`)
+
+Returns a `job_id` in the response body — you can `job watch` the crawl:
+```json
+{
+    "message":     "Crawl job enqueued",
+    "business_id": "...",
+    "job_id":      "...",
+    "status":      "crawling"
+}
+```
+
+### `POST /businesses` (used by `business create`)
+
+- `industry` must be one of: `automotive` `beauty` `consulting` `education` `entertainment` `finance` `fitness` `government` `healthcare` `home_services` `hospitality` `legal` `manufacturing` `non_profit` `real_estate` `restaurant` `retail` `technology` `other`
+- `website` must be a publicly DNS-resolvable domain — fabricated domains (e.g. `example.com`, `acme-test.example.com`) will return 422
+- `description` minimum ~50 characters
+
+### `POST /audit/start` (used by `audit start`)
+
+```json
+{
+    "named_audit_id": "<template uuid>",
+    "business_id":    "<optional override>"
+}
+```
+
+The old shape `{"business_id": ...}` returns 422 — `named_audit_id` is required.
+
+## Testing Patterns
+
+Tests use `respx` for HTTP mocking. Key patterns from `tests/test_pipeline.py`:
+
+**Pre-seeding a login token** (avoids needing to mock the auth flow):
+```python
+def _setup_logged_in(tmp_path, monkeypatch):
+    # redirect config to tmp_path, then write credentials
+    creds_file.write_text(json.dumps({"dev": "test-jwt-dev-token"}))
+```
+
+**Mocking `watch_job`** to avoid `time.sleep` and Rich `Live` renderer in tests:
+```python
+monkeypatch.setattr(
+    "cited_cli.commands.job.watch_job",
+    lambda client, path, console, poll_interval=2.0: {"status": "completed", "job_id": "..."},
+)
+```
+
+**Threading IDs between commands** (the `--json` pattern):
+```python
+result = runner.invoke(app, ["--env", "dev", "--json", "business", "create", ...])
+business_id = json.loads(result.output)["id"]  # thread into next command
+```
+
+**Verifying request payload** (not just response):
+```python
+captured_body = {}
+def _capture(request):
+    captured_body.update(json.loads(request.content))
+    return httpx.Response(202, json=MOCK_RESPONSE)
+respx.post(f"{DEV_API}/audit/start").mock(side_effect=_capture)
+# ... invoke command ...
+assert captured_body["named_audit_id"] == TEMPLATE_ID
+assert "recommendation_id" not in captured_body  # old field must not appear
+```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 # Cited CLI
 
-Command-line interface for the [Cited](https://youcited.com) GEO (Generative Engine Optimization) platform.
+Command-line interface for the [Cited](https://youcited.com) GEO (Generative Engine Optimization) platform. Audit how often your business is cited by AI assistants, generate recommendations, and produce AI-ready content solutions — all from the terminal or a Python script.
 
 ## Installation
+
+### Homebrew (recommended)
+
+```bash
+brew tap cited/tap
+brew install cited
+```
 
 ### From source (development)
 
@@ -12,86 +19,430 @@ cd homebrew-cited
 pip install -e ".[dev]"
 ```
 
-### Homebrew (coming soon)
-
-```bash
-brew tap cited/tap
-brew install cited
-```
-
 ## Quick Start
 
 ```bash
-# Log in
-cited auth login
+# Log in (opens browser by default)
+cited login
 
-# Check connection
+# Check you're connected
 cited status
 
-# List businesses
+# List your businesses
 cited business list
 
-# Run an audit
-cited audit start <business-id>
-
-# Watch job progress
-cited job watch <job-id>
-
-# Get results
-cited audit result <job-id>
+# See all commands
+cited --help
+cited audit --help
+cited audit template --help
 ```
+
+For the full end-to-end workflow — creating a business, running a GEO audit, and generating content solutions — see the [GEO Audit Pipeline](#geo-audit-pipeline) section below.
+
+---
+
+## Authentication
+
+```bash
+# Browser login (default — opens youcited.com login page)
+cited login
+
+# Specific OAuth provider
+cited login --provider google
+cited login --provider microsoft
+cited login --provider github
+
+# Password login (non-interactive / CI)
+cited login --email you@example.com --password "Secret123!"
+
+# Check status
+cited auth status
+
+# Log out
+cited logout
+```
+
+**Password registration** is a two-step email-verification flow:
+
+```bash
+cited register --email you@example.com --name "Your Name" --password "Secret123!"
+# → Check your inbox, paste the verification URL when prompted
+```
+
+---
 
 ## Global Flags
 
+These flags apply to every command and must be placed immediately after `cited`:
+
 | Flag | Short | Description |
 |------|-------|-------------|
-| `--json` | `-j` | JSON output (agent-friendly) |
-| `--env` | `-e` | Target environment: dev, prod, local |
-| `--profile` | `-p` | Config profile |
+| `--json` | `-j` | Machine-readable JSON output (great for scripting) |
+| `--env` | `-e` | Environment: `dev`, `prod`, `local` (default: `prod`) |
+| `--profile` | `-p` | Config profile to use |
 | `--verbose` | `-v` | Debug logging |
 | `--quiet` | `-q` | Minimal output |
-| `--no-color` | | Disable colors |
+| `--no-color` | | Disable colors (auto-applied when stdout is not a TTY) |
 
-## Commands
+---
+
+## GEO Audit Pipeline
+
+The complete workflow from business registration through AI-ready content solutions. Each step captures an ID for the next — just like piping commands together.
+
+### Prerequisites
+
+- `jq` installed (`brew install jq`) for ID extraction in bash
+- A publicly resolvable website domain (not `example.com`)
+- Account logged in: `cited login`
+
+### Step 1 — Create your business profile
+
+```bash
+BUSINESS_ID=$(cited --json business create \
+  --name        "Acme Corp" \
+  --website     "https://acme.com" \
+  --description "Acme builds AI-powered tools for enterprise productivity teams." \
+  --industry    "technology" \
+  | jq -r '.id')
+
+echo "Business: $BUSINESS_ID"
+```
+
+> **`--industry` must be one of:**
+> `automotive` `beauty` `consulting` `education` `entertainment` `finance`
+> `fitness` `government` `healthcare` `home_services` `hospitality` `legal`
+> `manufacturing` `non_profit` `real_estate` `restaurant` `retail` `technology` `other`
+
+### Step 2 — Scan your website
+
+The crawler reads your site so the platform understands your content, products, and brand signals.
+
+```bash
+CRAWL_JOB=$(cited --json business crawl $BUSINESS_ID | jq -r '.job_id')
+cited job watch $CRAWL_JOB
+
+# View crawl results as health score bars
+cited business health $BUSINESS_ID
+```
+
+### Step 3 — Create an audit template
+
+An audit template defines the questions you want AI assistants to answer. Ask questions your target buyers would actually type.
+
+```bash
+TEMPLATE_ID=$(cited --json audit template create \
+  --name     "Q4 GEO Audit" \
+  --business $BUSINESS_ID \
+  --question "Are we cited when people ask about AI productivity tools?" \
+  --question "Does our product appear in enterprise software recommendations?" \
+  --question "Are we mentioned when users research our core use case?" \
+  | jq -r '.id')
+
+echo "Template: $TEMPLATE_ID"
+
+# List all templates for a business
+cited audit template list --business $BUSINESS_ID
+
+# Inspect a template
+cited audit template get $TEMPLATE_ID
+```
+
+Auto-generated questions are rarely perfect out of the box. Refine them before running the audit:
+
+```bash
+# Replace all questions (--question flags replace the full list)
+cited audit template update $TEMPLATE_ID \
+  --question "Are we cited when enterprise buyers ask about AI safety?" \
+  --question "Does our product appear in responsible AI recommendations?" \
+  --question "Are we mentioned when developers compare AI platforms?"
+
+# Update just the name (keeps existing questions)
+cited audit template update $TEMPLATE_ID --name "Q4 GEO Audit v2"
+
+# Verify changes
+cited audit template get $TEMPLATE_ID
+```
+
+### Step 4 — Run the audit
+
+```bash
+AUDIT_JOB=$(cited --json audit start $TEMPLATE_ID --business $BUSINESS_ID \
+  | jq -r '.job_id')
+
+# Watch live progress bar
+cited job watch $AUDIT_JOB
+
+# View results: per-question citation data across providers
+cited audit result $AUDIT_JOB
+```
+
+### Step 5 — Generate recommendations
+
+```bash
+RECO_JOB=$(cited --json recommend start $AUDIT_JOB | jq -r '.job_id')
+cited job watch $RECO_JOB
+```
+
+### Step 6 — Discover what to fix
+
+`recommend insights` prints a table of all actionable items with the source IDs you'll need for the next step:
+
+```bash
+cited recommend insights $RECO_JOB
+```
 
 ```
-cited auth login|logout|status|token
+                          Available Insights
+┏━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ # ┃ Type              ┃ Source ID                ┃ Description              ┃
+┡━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ 1 │ question_insight  │ d5b17bda-fa5b-48ff-...   │ Are we cited for AI...   │
+│ 2 │ head_to_head      │ wikipedia.org            │ wikipedia.org            │
+│ 3 │ strengthening_tip │ llms_txt                 │ Create llms.txt for AI   │
+└───┴───────────────────┴──────────────────────────┴──────────────────────────┘
+
+Run a solution: cited solution start $RECO_JOB --type <type> --source <source_id>
+```
+
+### Step 7 — Generate a content solution
+
+Pick a row from the insights table and pass its type and source ID:
+
+```bash
+cited solution start $RECO_JOB \
+  --type   question_insight \
+  --source d5b17bda-fa5b-48ff-8238-a644c78b404a
+
+# → ✓ Solution Started
+# → Track progress: cited job watch <sol_job_id>
+# → View artifacts: https://app.youcited.com/solutions/<sol_job_id>
+```
+
+**`--type` values:** `question_insight` · `head_to_head` · `strengthening_tip` · `priority_action`
+
+> Rich solution artifacts (blog posts, FAQ schemas, structured content) are rendered in the web app.
+> The CLI prints the direct link so you can jump straight there.
+
+---
+
+## Scripting & Automation
+
+Every command supports `--json` output, making the CLI a first-class building block for automation pipelines — in bash, Python, or any language that can run a subprocess.
+
+### Bash with `jq`
+
+```bash
+# Capture IDs by piping --json output through jq
+BUSINESS_ID=$(cited --json business create --name "..." --website "..." \
+  --description "..." --industry "technology" | jq -r '.id')
+
+TEMPLATE_ID=$(cited --json audit template create \
+  --name "My Audit" --business $BUSINESS_ID \
+  --question "Are we cited for X?" | jq -r '.id')
+
+AUDIT_JOB=$(cited --json audit start $TEMPLATE_ID | jq -r '.job_id')
+cited job watch $AUDIT_JOB
+
+RECO_JOB=$(cited --json recommend start $AUDIT_JOB | jq -r '.job_id')
+cited job watch $RECO_JOB
+
+# Extract first question insight source_id
+SOURCE_ID=$(cited --json recommend result $RECO_JOB \
+  | jq -r '.question_insights[0].question_id')
+
+cited solution start $RECO_JOB --type question_insight --source $SOURCE_ID
+```
+
+### Python
+
+The CLI is a thin, authenticated HTTP wrapper — Python scripts can drive it directly via `subprocess` with no extra dependencies. This is the same pattern used by the integration test suite.
+
+```python
+#!/usr/bin/env python3
+"""
+cited-pipeline.py — Automate a full GEO audit pipeline.
+
+Requirements: `cited` CLI installed and authenticated (`cited login` first).
+Usage:        python3 cited-pipeline.py
+"""
+import json
+import subprocess
+
+ENV = "dev"  # or "prod"
+
+
+def cited_json(*args: str) -> dict | list:
+    """Run a cited command with --json and return parsed output."""
+    result = subprocess.run(
+        ["cited", "--env", ENV, "--json", *args],
+        capture_output=True, text=True, check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def cited_watch(*args: str) -> None:
+    """Run a cited command streaming human output live (progress bars, tables)."""
+    subprocess.run(["cited", "--env", ENV, *args], check=True)
+
+
+# ── Step 1: Create business ───────────────────────────────────────────────────
+print("→ Creating business...")
+business = cited_json(
+    "business", "create",
+    "--name",        "Acme Corp",
+    "--website",     "https://acme.com",
+    "--description", "Acme builds AI-powered tools for enterprise productivity teams.",
+    "--industry",    "technology",
+)
+business_id = business["id"]
+print(f"  Business: {business_id}")
+
+# ── Step 2: Scan the website ──────────────────────────────────────────────────
+print("→ Scanning website...")
+crawl = cited_json("business", "crawl", business_id)
+if crawl_job := crawl.get("job_id"):
+    cited_watch("job", "watch", crawl_job)
+
+# ── Step 3: Create audit template ────────────────────────────────────────────
+print("→ Creating audit template...")
+template = cited_json(
+    "audit", "template", "create",
+    "--name",     "Q4 GEO Audit",
+    "--business", business_id,
+    "--question", "Are we cited when people ask about AI productivity tools?",
+    "--question", "Does our product appear in enterprise software recommendations?",
+    "--question", "Are we mentioned when users research our core use case?",
+)
+template_id = template["id"]
+print(f"  Template: {template_id}")
+
+# ── Step 3b: Refine questions (auto-generated questions usually need tuning) ─
+print("→ Refining template questions...")
+updated = cited_json(
+    "audit", "template", "update", template_id,
+    "--question", "Are we cited when enterprise buyers ask about AI safety?",
+    "--question", "Does our product appear in responsible AI recommendations?",
+    "--question", "Are we mentioned when developers compare AI platforms?",
+)
+print(f"  Updated: {len(updated['questions'])} questions")
+
+# ── Step 4: Run the audit ─────────────────────────────────────────────────────
+print("→ Starting audit...")
+audit = cited_json("audit", "start", template_id, "--business", business_id)
+audit_job = audit["job_id"]
+cited_watch("job", "watch", audit_job)
+
+# ── Step 5: Generate recommendations ─────────────────────────────────────────
+print("→ Generating recommendations...")
+recommend = cited_json("recommend", "start", audit_job)
+reco_job = recommend["job_id"]
+cited_watch("job", "watch", reco_job)
+
+# ── Step 6: View available insights ──────────────────────────────────────────
+print("→ Available insights:")
+cited_watch("recommend", "insights", reco_job)
+
+# ── Step 7: Start a content solution ─────────────────────────────────────────
+# Extract source IDs directly from the JSON result
+result = cited_json("recommend", "result", reco_job)
+question_insights = result.get("question_insights", [])
+
+if question_insights:
+    source_id = question_insights[0]["question_id"]
+    print(f"→ Solving: {question_insights[0]['question_text'][:60]}...")
+    solution = cited_json(
+        "solution", "start", reco_job,
+        "--type",   "question_insight",
+        "--source", source_id,
+    )
+    sol_job = solution["job_id"]
+    print(f"  Solution job:    {sol_job}")
+    print(f"  View artifacts:  https://{ENV}.youcited.com/solutions/{sol_job}")
+
+print("\n✓ Pipeline complete!")
+```
+
+The `cited_json()` / `cited_watch()` pattern — capture IDs from `--json` output, stream human output for long-running jobs — is exactly what the integration test suite uses internally with mocked HTTP responses.
+
+---
+
+## Command Reference
+
+```
+cited login                               Log in (top-level alias)
+cited logout                              Log out (top-level alias)
+cited register                            Register new account (top-level alias)
+cited status                              API health check
+cited version                             Show CLI version
+
+cited auth login|logout|register|status|token
+
 cited config set|get|show|environments
+
 cited business list|get|create|update|delete|health|crawl
-cited audit start|status|result|list|export
-cited recommend start|status|result|list
-cited solution start|status|result|list
-cited hq <business_id> [--full] [--personas] [--products]
+
+cited audit template list|get|create|update|delete   ← Manage audit templates
+cited audit start|status|result|list|export   ← Run and inspect audits
+
+cited recommend start|status|result|list      ← Generate recommendations
+cited recommend insights                      ← View actionable source table
+
+cited solution start|status|result|list       ← Generate content solutions
+
+cited hq <business_id> [--full] [--personas] [--products] [--intents] [--actions]
+
 cited analytics compare|trends|summary
+
 cited agent facts|claims|comparison|semantic-health|buyer-fit
+
 cited job watch|cancel
-cited status
-cited version
 ```
+
+---
 
 ## Configuration
 
 Config is stored in `~/.cited/config.toml`:
 
 ```bash
-# Set default environment
+# Set default environment (saves typing --env dev every time)
 cited config set environment dev
 
-# Set default business
+# Set a default business (used by commands that accept --business)
 cited config set default_business_id <uuid>
 
-# Set agent API key
+# Set Agent API key (for cited agent commands)
 cited config set agent_api_key <key>
+
+# Inspect current config
+cited config show
+cited config environments
 ```
+
+---
 
 ## JSON Output
 
-All commands support `--json` for structured output:
+All commands write clean JSON to stdout with `--json`, enabling pipelines with `jq`, `python3 -c`, or any other tool:
 
 ```bash
+# Extract specific fields
 cited --json business list | jq '.[].name'
+cited --json audit result <id> | jq '.overall_citation_rate'
+cited --json recommend result <id> | jq '.question_insights[].question_text'
+
+# Save full results
 cited --json audit result <id> > audit.json
+cited --json recommend result <id> > recommendations.json
+
+# Count citations by provider
+cited --json audit result <id> | jq '[.citations_pulled[].provider_name] | group_by(.) | map({provider: .[0], count: length})'
 ```
+
+Errors always go to **stderr** as `{"error": true, "message": "..."}` so they never corrupt stdout pipelines.
+
+---
 
 ## Exit Codes
 
@@ -104,11 +455,14 @@ cited --json audit result <id> > audit.json
 | 4 | Validation error |
 | 5 | Rate limited |
 
+---
+
 ## Development
 
 ```bash
 pip install -e ".[dev]"
-pytest -v
+pytest -v                                       # All tests
+pytest tests/test_pipeline.py -v               # Pipeline integration tests
 ruff check src/
-mypy src/cited_cli/
+mypy src/cited_cli/ --ignore-missing-imports
 ```

--- a/TEST_RUNBOOK.md
+++ b/TEST_RUNBOOK.md
@@ -1,6 +1,18 @@
 # Cited CLI — Test Runbook
 
-Comprehensive test commands organized by workflow stage. Each section builds on the previous one. Replace placeholder IDs with actual values as you go.
+Comprehensive test commands organized by workflow stage. Each section builds on the previous one.
+
+**Convention:** Commands that return an ID are shown with bash variable capture — replace placeholder values with real IDs as you run each step. The `--json` flag gives clean JSON output for extraction.
+
+```bash
+# Portable ID extraction — works without jq:
+BUSINESS_ID=$(cited --json business create ... | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+
+# If you have jq installed (cleaner):
+BUSINESS_ID=$(cited --json business create ... | jq -r '.id')
+```
+
+---
 
 ## 1. System & Config
 
@@ -14,7 +26,7 @@ cited --env dev status
 cited --env prod status
 cited --json --env dev status
 
-# Configure default environment
+# Configure default environment (saves typing --env dev every time)
 cited config set environment dev
 cited config get environment
 cited config show
@@ -22,14 +34,33 @@ cited config environments
 cited --json config environments
 ```
 
+---
+
 ## 2. Authentication
 
 ```bash
-# Login (interactive — will prompt for password)
-cited auth login --email <your-email>
+# --- Top-level login (preferred) ---
 
-# Login (non-interactive — scriptable)
+# Browser login (default — opens youcited login page)
+cited login
+
+# Browser login with specific OAuth provider
+cited login --provider google
+cited login --provider microsoft
+cited login --provider github
+
+# Password login (interactive — prompts for password)
+cited login --email <your-email>
+
+# Password login (non-interactive — scriptable / CI)
+cited login --email <your-email> --password <your-password>
+
+# --- Backward-compatible subcommand (same behavior) ---
 cited auth login --email <your-email> --password <your-password>
+
+# --- Token paste fallback ---
+# If browser callback times out (firewall, WSL, SSH), the CLI will prompt
+# you to paste the token shown on the browser success page.
 
 # Verify session
 cited auth status
@@ -39,9 +70,14 @@ cited --json auth status
 cited auth token
 cited auth token | head -c 50   # Verify it's a JWT
 
-# Test wrong credentials (should exit code 2)
-cited auth login --email fake@example.com --password wrong; echo "Exit: $?"
+# Test wrong credentials (should exit 2)
+cited login --email fake@example.com --password wrong; echo "Exit: $?"
+
+# Test invalid provider (should exit 4)
+cited login --provider facebook; echo "Exit: $?"
 ```
+
+---
 
 ## 3. Business CRUD
 
@@ -51,171 +87,328 @@ cited business list
 cited --json business list
 
 # Create a test business
-cited business create --name "CLI Test Corp" --website "https://example.com" --industry "Technology"
-# ^^^ Save the returned business ID as $BIZ_ID
+# IMPORTANT: website must be a publicly resolvable domain (not example.com)
+# IMPORTANT: industry must be one of the enum values below
+BUSINESS_ID=$(cited --json business create \
+  --name        "CLI Test Corp" \
+  --website     "https://anthropic.com" \
+  --description "A test technology company for validating CLI runbook commands and GEO workflows." \
+  --industry    "technology" \
+  | jq -r '.id')
+echo "BUSINESS_ID=$BUSINESS_ID"
+
+# Valid --industry values:
+# automotive  beauty  consulting  education  entertainment  finance
+# fitness  government  healthcare  home_services  hospitality  legal
+# manufacturing  non_profit  real_estate  restaurant  retail  technology  other
 
 # Get business details
-cited business get <BIZ_ID>
-cited --json business get <BIZ_ID>
+cited business get $BUSINESS_ID
+cited --json business get $BUSINESS_ID
 
 # Update business
-cited business update <BIZ_ID> --name "CLI Test Corp Updated"
-cited business update <BIZ_ID> --website "https://example.org"
+cited business update $BUSINESS_ID --name "CLI Test Corp Updated"
+cited business update $BUSINESS_ID --website "https://anthropic.com"
 
-# Health scores
-cited business health <BIZ_ID>
-cited --json business health <BIZ_ID>
-
-# Trigger crawl
-cited business crawl <BIZ_ID>
+# Health scores (meaningful after a crawl has run)
+cited business health $BUSINESS_ID
+cited --json business health $BUSINESS_ID
 ```
 
-## 4. Audit Workflow (full pipeline)
+---
+
+## 4. Audit Templates
+
+Audit templates define the GEO questions you want answered — "Are we cited when people ask about X?" Each template is reusable across multiple audit runs.
+
+Auto-generated questions are rarely perfect out of the box. The typical flow is: **create → review → refine → run audit**. Use `audit template update` to revise questions before starting an audit.
 
 ```bash
-# Start an audit (use a business that has crawl data)
-cited audit start <BIZ_ID>
-# ^^^ Save the returned job_id as $AUDIT_JOB
+# Create a template with multiple questions (--question is repeatable)
+TEMPLATE_ID=$(cited --json audit template create \
+  --name        "Q4 GEO Audit" \
+  --business    $BUSINESS_ID \
+  --description "Checks citation presence across key AI and technology queries" \
+  --question    "Are we cited when people ask about AI productivity tools?" \
+  --question    "Does our product appear in enterprise software recommendations?" \
+  --question    "Are we mentioned when users research our core use case?" \
+  | jq -r '.id')
+echo "TEMPLATE_ID=$TEMPLATE_ID"
 
-# Watch it run (live progress bar)
-cited job watch <AUDIT_JOB>
+# List templates for a business
+cited audit template list
+cited audit template list --business $BUSINESS_ID
+cited --json audit template list --business $BUSINESS_ID
 
-# Or poll status manually
-cited audit status <AUDIT_JOB>
-cited --json audit status <AUDIT_JOB>
+# Inspect a template (shows all questions numbered)
+cited audit template get $TEMPLATE_ID
+cited --json audit template get $TEMPLATE_ID
 
-# Get results when complete
-cited audit result <AUDIT_JOB>
-cited --json audit result <AUDIT_JOB>
+# ── Update / refine questions before running an audit ──
+
+# Replace ALL questions (--question flags replace the full list)
+cited audit template update $TEMPLATE_ID \
+  --question "Are we cited when enterprise buyers ask about AI safety?" \
+  --question "Does Anthropic appear in responsible AI recommendations?" \
+  --question "Are we mentioned when developers compare AI platforms?"
+
+# Update just the name or description (keeps existing questions)
+cited audit template update $TEMPLATE_ID --name "Q4 GEO Audit v2"
+cited audit template update $TEMPLATE_ID --description "Revised scope for Q4"
+
+# Update everything at once
+cited audit template update $TEMPLATE_ID \
+  --name "Q4 GEO Audit v2" \
+  --description "Focused on enterprise buyer queries" \
+  --question "Do enterprise teams find us when researching AI tools?" \
+  --question "Are we cited in AI safety and alignment discussions?"
+
+# Verify changes
+cited audit template get $TEMPLATE_ID
+
+# JSON output (for scripting)
+cited --json audit template update $TEMPLATE_ID \
+  --question "Updated question 1" \
+  --question "Updated question 2"
+
+# Delete a template
+cited audit template delete $TEMPLATE_ID --yes        # skip confirmation
+cited audit template delete $TEMPLATE_ID              # prompts for confirmation
+```
+
+---
+
+## 5. Crawl (Scan Website)
+
+The crawler reads your site so the platform understands your content, structure, and brand signals. Run this before your first audit for best results.
+
+```bash
+# Trigger a crawl — returns a job_id you can watch
+CRAWL_JSON=$(cited --json business crawl $BUSINESS_ID)
+CRAWL_JOB=$(echo $CRAWL_JSON | jq -r '.job_id')
+echo "CRAWL_JOB=$CRAWL_JOB"
+
+# Watch live progress until complete
+cited job watch $CRAWL_JOB
+
+# View crawl results as health score bars
+cited business health $BUSINESS_ID
+cited --json business health $BUSINESS_ID
+```
+
+---
+
+## 6. Audit Workflow
+
+```bash
+# Start an audit from a template
+# IMPORTANT: first argument is the template (named_audit) ID, not the business ID
+AUDIT_JSON=$(cited --json audit start $TEMPLATE_ID --business $BUSINESS_ID)
+AUDIT_JOB=$(echo $AUDIT_JSON | jq -r '.job_id')
+echo "AUDIT_JOB=$AUDIT_JOB"
+
+# Start with specific citation providers
+cited audit start $TEMPLATE_ID --provider openai --provider perplexity
+
+# Watch live progress bar
+cited job watch $AUDIT_JOB
+cited job watch $AUDIT_JOB --type audit         # explicit type (skips auto-detect probe)
+cited job watch $AUDIT_JOB --interval 5         # poll every 5 seconds
+
+# Poll status manually
+cited audit status $AUDIT_JOB
+cited --json audit status $AUDIT_JOB
+
+# Get full results when complete (large JSON — pipe to jq for a summary)
+cited audit result $AUDIT_JOB
+cited --json audit result $AUDIT_JOB
+cited --json audit result $AUDIT_JOB | jq '{total_citations: (.citations_pulled | length), citation_score: .citation_score}'
 
 # List audit history
 cited audit list
-cited audit list --business <BIZ_ID>
-cited --json audit list --business <BIZ_ID>
+cited audit list --business $BUSINESS_ID
+cited --json audit list --business $BUSINESS_ID
 
-# Export PDF
-cited audit export <AUDIT_JOB>
-cited audit export <AUDIT_JOB> --output my-audit.pdf
+# Export PDF report
+cited audit export $AUDIT_JOB
+cited audit export $AUDIT_JOB --output my-audit.pdf
 ls -la *.pdf
 ```
 
-## 5. Recommendations (requires completed audit)
+---
+
+## 7. Recommendations (requires completed audit)
 
 ```bash
-# Generate recommendations from audit
-cited recommend start <AUDIT_JOB>
-# ^^^ Save the returned job_id as $RECO_JOB
+# Generate recommendations from an audit
+RECO_JSON=$(cited --json recommend start $AUDIT_JOB)
+RECO_JOB=$(echo $RECO_JSON | jq -r '.job_id')
+echo "RECO_JOB=$RECO_JOB"
 
 # Watch progress
-cited job watch <RECO_JOB>
+cited job watch $RECO_JOB
+cited job watch $RECO_JOB --type recommendations
 
-# Check status / results
-cited recommend status <RECO_JOB>
-cited recommend result <RECO_JOB>
-cited --json recommend result <RECO_JOB>
+# Check status / full raw results
+cited recommend status $RECO_JOB
+cited recommend result $RECO_JOB
+cited --json recommend result $RECO_JOB
+
+# *** View insights table — the key discovery step before running solutions ***
+# Shows all actionable items with their source_type and source_id
+cited recommend insights $RECO_JOB
+
+# In --json mode, insights returns the same raw result as 'recommend result'
+# but it's useful for scripting source_id extraction:
+SOURCE_ID=$(cited --json recommend insights $RECO_JOB \
+  | jq -r '.question_insights[0].question_id')
+echo "SOURCE_ID=$SOURCE_ID"
 
 # List recommendation history
 cited recommend list
-cited recommend list --audit <AUDIT_JOB>
+cited recommend list --audit $AUDIT_JOB
 ```
 
-## 6. Solutions (requires completed recommendation)
+### Understanding the insights table
+
+`cited recommend insights` renders a table with four source types:
+
+| Type | Source ID | Where it comes from |
+|------|-----------|-------------------|
+| `question_insight` | UUID (`question_id` field) | One per audit question with low citation score |
+| `head_to_head` | Domain string (e.g. `wikipedia.org`) | `competitor_domain` field in `head_to_head_comparisons` |
+| `strengthening_tip` | Category string (e.g. `llms_txt`) | `category` field in `strengthening_tips` |
+| `priority_action` | ID or category | From `priority_actions` |
+
+---
+
+## 8. Solutions (requires completed recommendation)
 
 ```bash
-# Generate solution from a recommendation
-cited solution start <RECOMMENDATION_ID>
-# ^^^ Save the returned job_id as $SOL_JOB
+# First, run 'cited recommend insights $RECO_JOB' to see available source types and IDs
+cited recommend insights $RECO_JOB
+
+# Start a solution — specify the recommendation job, source type, and source ID
+cited solution start $RECO_JOB \
+  --type   question_insight \
+  --source <source_id_from_insights_table>
+
+# Other source types:
+cited solution start $RECO_JOB --type head_to_head      --source <competitor_domain>
+cited solution start $RECO_JOB --type strengthening_tip --source <category>
+cited solution start $RECO_JOB --type priority_action   --source <source_id>
+
+# The CLI prints:
+# → "Track progress: cited job watch <sol_job_id>"
+# → "View artifacts: https://dev.youcited.com/solutions/<sol_job_id>"
+#   (artifacts are rich documents — open the link in the web app)
+
+SOL_JOB=<job_id_from_solution_start_output>
 
 # Watch progress
-cited job watch <SOL_JOB>
+cited job watch $SOL_JOB
+cited job watch $SOL_JOB --type solutions
 
 # Check status / results
-cited solution status <SOL_JOB>
-cited solution result <SOL_JOB>
-cited --json solution result <SOL_JOB>
+cited solution status $SOL_JOB
+cited solution result $SOL_JOB
+cited --json solution result $SOL_JOB
 
 # List solution history
 cited solution list
-cited solution list --business <BIZ_ID>
+cited solution list --business $BUSINESS_ID
 ```
 
-## 7. Business HQ Dashboard
+---
+
+## 9. Business HQ Dashboard
 
 ```bash
-# Basic dashboard
-cited hq <BIZ_ID>
+# Basic dashboard (health scores + summary)
+cited hq $BUSINESS_ID
 
 # With additional sections
-cited hq <BIZ_ID> --personas
-cited hq <BIZ_ID> --products
-cited hq <BIZ_ID> --actions
-cited hq <BIZ_ID> --personas --products --intents --actions
+cited hq $BUSINESS_ID --personas
+cited hq $BUSINESS_ID --products
+cited hq $BUSINESS_ID --actions
+cited hq $BUSINESS_ID --personas --products --intents --actions
 
-# Full heavy load (all data)
-cited hq <BIZ_ID> --full
+# Full heavy load (all data in one request)
+cited hq $BUSINESS_ID --full
 
 # JSON output (great for piping to jq)
-cited --json hq <BIZ_ID> --full
-cited --json hq <BIZ_ID> --full | jq '.health_scores'
+cited --json hq $BUSINESS_ID --full
+cited --json hq $BUSINESS_ID --full | jq '.health_scores'
 ```
 
-## 8. Analytics
+---
+
+## 10. Analytics
 
 ```bash
 # KPI trends over time
-cited analytics trends <BIZ_ID>
-cited --json analytics trends <BIZ_ID>
+cited analytics trends $BUSINESS_ID
+cited --json analytics trends $BUSINESS_ID
 
 # Business summary
-cited analytics summary <BIZ_ID>
-cited --json analytics summary <BIZ_ID>
+cited analytics summary $BUSINESS_ID
+cited --json analytics summary $BUSINESS_ID
 
 # Compare audit against baseline
-cited analytics compare <AUDIT_JOB>
+cited analytics compare $AUDIT_JOB
 ```
 
-## 9. Agent API (requires API key)
+---
+
+## 11. Agent API (requires API key)
 
 ```bash
 # Set agent API key
 cited config set agent_api_key <your-agent-api-key>
 
 # Business facts
-cited agent facts <BIZ_ID>
-cited --json agent facts <BIZ_ID>
+cited agent facts $BUSINESS_ID
+cited --json agent facts $BUSINESS_ID
 
 # Verifiable claims
-cited agent claims <BIZ_ID>
+cited agent claims $BUSINESS_ID
 
 # Competitive comparison
-cited agent comparison <BIZ_ID>
+cited agent comparison $BUSINESS_ID
 
 # Semantic health
-cited agent semantic-health <BIZ_ID>
+cited agent semantic-health $BUSINESS_ID
 
 # Buyer-fit simulation
 cited agent buyer-fit --query "best GEO platform for e-commerce"
-cited agent buyer-fit --query "enterprise SEO tool" --business <BIZ_ID>
-cited --json agent buyer-fit --query "best GEO platform" --business <BIZ_ID>
+cited agent buyer-fit --query "enterprise SEO tool" --business $BUSINESS_ID
+cited --json agent buyer-fit --query "best GEO platform" --business $BUSINESS_ID
 ```
 
-## 10. Job Management
+---
+
+## 12. Job Management
 
 ```bash
-# Start a long-running job and cancel it
-cited audit start <BIZ_ID>
-# ^^^ Note the job_id
-cited job cancel <JOB_ID>
+# Watch any job by ID (auto-detects type)
+cited job watch $JOB_ID
 
-# Watch with custom poll interval
-cited job watch <JOB_ID> --interval 5
+# Explicit type skips the auto-detect probe (faster, no extra HTTP call)
+cited job watch $JOB_ID --type audit
+cited job watch $JOB_ID --type recommendations
+cited job watch $JOB_ID --type solutions
 
-# Specify job type explicitly (skips auto-detection probe)
-cited job watch <JOB_ID> --type audit
-cited job cancel <JOB_ID> --type recommendations
+# Custom poll interval
+cited job watch $JOB_ID --interval 5
+
+# Cancel a running job
+cited job cancel $JOB_ID
+cited job cancel $JOB_ID --type audit
 ```
 
-## 11. Global Flags & Edge Cases
+---
+
+## 13. Global Flags & Edge Cases
 
 ```bash
 # JSON mode on everything
@@ -225,7 +418,7 @@ cited --json auth status
 cited --json business list
 cited --json audit list
 
-# Quiet mode
+# Quiet mode (minimal output)
 cited --quiet auth status
 cited --quiet business list
 
@@ -233,66 +426,311 @@ cited --quiet business list
 cited --no-color business list
 cited --no-color status
 
-# Pipe-friendly (auto-detects non-TTY)
+# Pipe-friendly (auto-detects non-TTY and disables color)
 cited business list | cat
 cited --json business list | jq '.[0].name'
 
 # Environment switching inline
-cited --env dev status
+cited --env dev  status
 cited --env prod status
-cited --env dev business list
+cited --env dev  business list
 cited --env prod business list
 
-# Error handling (verify exit codes)
-cited business get nonexistent-id; echo "Exit: $?"           # Should be 3 (not found)
-cited --env dev auth login --email bad --password bad; echo "Exit: $?"  # Should be 2 (auth)
-cited business update <BIZ_ID>; echo "Exit: $?"              # Should be 4 (validation - no fields)
+# Error handling — verify exit codes
+cited business get nonexistent-id; echo "Exit: $?"           # 3 (not found)
+cited --env dev login --email bad --password bad; echo "Exit: $?"  # 2 (auth error)
+cited business update $BUSINESS_ID; echo "Exit: $?"          # 4 (validation — no fields given)
 ```
 
-## 12. Cleanup
+---
+
+## 14. Cleanup
 
 ```bash
-# Delete test business
-cited business delete <BIZ_ID> --yes
+# Delete test business (removes all associated data)
+cited business delete $BUSINESS_ID --yes
+
+# Delete test audit template
+cited audit template delete $TEMPLATE_ID --yes
 
 # Logout
-cited auth logout
+cited logout
 cited auth status   # Should fail with exit code 2
+```
+
+### Automated cleanup script
+
+If you forget to clean up (or a run fails partway through), use the cleanup script to find and remove test assets:
+
+```bash
+# Dry run — see what would be deleted
+python3 scripts/cleanup_dev.py --dry-run
+
+# Interactive — prompts you to pick which businesses to delete
+python3 scripts/cleanup_dev.py
+
+# Auto — deletes all businesses matching test name patterns (no prompts)
+python3 scripts/cleanup_dev.py --auto
+
+# Target a different environment
+python3 scripts/cleanup_dev.py --env prod --dry-run
+```
+
+The script detects test businesses by name patterns ("E2E Test", "CLI Test", etc.), deletes associated audit templates first, then the business itself.
+
+---
+
+## 15. Python Scripting
+
+Every command supports `--json` output, making the CLI a first-class building block for Python automation. The `subprocess.run` + `json.loads` pattern requires no extra dependencies — just the standard library.
+
+This is the same pattern used by the integration test suite (`tests/test_pipeline.py`).
+
+### Helper functions
+
+```python
+import json
+import subprocess
+
+ENV = "dev"  # or "prod"
+
+def cited_json(*args: str) -> dict | list:
+    """Run a cited command with --json and return parsed output."""
+    result = subprocess.run(
+        ["cited", "--env", ENV, "--json", *args],
+        capture_output=True, text=True, check=True,
+    )
+    return json.loads(result.stdout)
+
+def cited_watch(*args: str) -> None:
+    """Run a cited command streaming human output live (progress bars, tables)."""
+    subprocess.run(["cited", "--env", ENV, *args], check=True)
+```
+
+### Full pipeline script
+
+```python
+#!/usr/bin/env python3
+"""
+cited-pipeline.py — Automate a full GEO audit pipeline.
+
+Requirements: `cited` CLI installed and authenticated (`cited login` first).
+Usage:        python3 cited-pipeline.py
+"""
+import json
+import subprocess
+
+ENV = "dev"
+
+
+def cited_json(*args: str) -> dict | list:
+    result = subprocess.run(
+        ["cited", "--env", ENV, "--json", *args],
+        capture_output=True, text=True, check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def cited_watch(*args: str) -> None:
+    subprocess.run(["cited", "--env", ENV, *args], check=True)
+
+
+# ── Step 1: Create business ───────────────────────────────────────────────────
+print("→ Creating business...")
+business = cited_json(
+    "business", "create",
+    "--name",        "Acme Corp",
+    "--website",     "https://acme.com",
+    "--description", "Acme builds AI-powered tools for enterprise productivity teams.",
+    "--industry",    "technology",
+)
+BUSINESS_ID = business["id"]
+print(f"  Business: {BUSINESS_ID}")
+
+# ── Step 2: Scan the website ──────────────────────────────────────────────────
+print("→ Scanning website...")
+crawl = cited_json("business", "crawl", BUSINESS_ID)
+if crawl_job := crawl.get("job_id"):
+    cited_watch("job", "watch", crawl_job)
+
+# ── Step 3: Create audit template ────────────────────────────────────────────
+print("→ Creating audit template...")
+template = cited_json(
+    "audit", "template", "create",
+    "--name",     "Q4 GEO Audit",
+    "--business", BUSINESS_ID,
+    "--question", "Are we cited when people ask about AI productivity tools?",
+    "--question", "Does our product appear in enterprise software recommendations?",
+    "--question", "Are we mentioned when users research our core use case?",
+)
+TEMPLATE_ID = template["id"]
+print(f"  Template: {TEMPLATE_ID}")
+
+# ── Step 4: Run the audit ─────────────────────────────────────────────────────
+print("→ Starting audit...")
+audit = cited_json("audit", "start", TEMPLATE_ID, "--business", BUSINESS_ID)
+AUDIT_JOB = audit["job_id"]
+cited_watch("job", "watch", AUDIT_JOB)  # live progress bar in terminal
+
+# ── Step 5: Generate recommendations ─────────────────────────────────────────
+print("→ Generating recommendations...")
+recommend = cited_json("recommend", "start", AUDIT_JOB)
+RECO_JOB = recommend["job_id"]
+cited_watch("job", "watch", RECO_JOB)
+
+# ── Step 6: View available insights ──────────────────────────────────────────
+print("→ Available insights:")
+cited_watch("recommend", "insights", RECO_JOB)  # prints table to terminal
+
+# ── Step 7: Extract source IDs and start a solution ──────────────────────────
+# Use --json to get machine-readable data for source_id extraction
+result = cited_json("recommend", "result", RECO_JOB)
+question_insights = result.get("question_insights", [])
+
+if question_insights:
+    # question_id is the source_id for question_insight solutions
+    source_id = question_insights[0]["question_id"]
+    print(f"→ Solving: {question_insights[0]['question_text'][:60]}...")
+    solution = cited_json(
+        "solution", "start", RECO_JOB,
+        "--type",   "question_insight",
+        "--source", source_id,
+    )
+    SOL_JOB = solution["job_id"]
+    print(f"  Solution job:   {SOL_JOB}")
+    print(f"  View artifacts: https://{ENV}.youcited.com/solutions/{SOL_JOB}")
+else:
+    print("  No question insights found.")
+
+print("\n✓ Pipeline complete!")
+```
+
+### Ad-hoc scripting examples
+
+```python
+# List all businesses and print names
+businesses = cited_json("business", "list")
+for b in businesses:
+    print(b["name"], b["id"])
+
+# Get all audit templates for a business
+templates = cited_json("audit", "template", "list", "--business", BUSINESS_ID)
+for t in templates:
+    print(f"{t['name']} — {len(t['questions'])} questions — {t['id']}")
+
+# Refine template questions (common — auto-generated questions need tuning)
+updated = cited_json("audit", "template", "update", TEMPLATE_ID,
+    "--question", "Revised question 1",
+    "--question", "Revised question 2",
+)
+print(f"Updated: {len(updated['questions'])} questions")
+
+# Run an audit with multiple providers
+audit = cited_json("audit", "start", TEMPLATE_ID,
+    "--provider", "openai",
+    "--provider", "perplexity",
+)
+
+# Extract a summary from a completed recommendation
+result = cited_json("recommend", "result", RECO_JOB)
+print(f"Questions analyzed:  {result['total_questions']}")
+print(f"Wins / Losses / Ties: {result['record_wins']} / {result['record_losses']} / {result['record_ties']}")
+print(f"Insights available:  {len(result['question_insights'])} question, "
+      f"{len(result['head_to_head_comparisons'])} head-to-head, "
+      f"{len(result['strengthening_tips'])} tips")
+
+# Start solutions for ALL question insights automatically
+for qi in result["question_insights"]:
+    sol = cited_json("solution", "start", RECO_JOB,
+        "--type",   "question_insight",
+        "--source", qi["question_id"],
+    )
+    print(f"  Started solution {sol['job_id']} for: {qi['question_text'][:50]}")
 ```
 
 ---
 
 ## End-to-End Pipeline
 
-The single deepest-path test — exercises auth, CRUD, async jobs, polling, PDF generation, and cleanup:
+The complete deepest-path test — exercises auth, business CRUD, crawl, audit templates, async jobs, recommendations, insights, solutions, HQ dashboard, and cleanup. Run this against dev before any significant release.
 
 ```bash
+# ── Setup ─────────────────────────────────────────────────────────────────────
 cited config set environment dev
-cited auth login --email <your-email> --password <your-password>
-cited business create --name "E2E Test" --website "https://example.com" --industry "Technology"
-# ^^^ capture BIZ_ID
+cited login --email <your-email> --password <your-password>
+cited auth status   # Verify logged in
 
-cited business crawl <BIZ_ID>
-# wait for crawl to complete
+# ── Step 1: Create business ────────────────────────────────────────────────────
+BUSINESS_ID=$(cited --json business create \
+  --name        "E2E Test $(date +%H%M%S)" \
+  --website     "https://anthropic.com" \
+  --description "End-to-end test business for validating the full CLI pipeline." \
+  --industry    "technology" \
+  | jq -r '.id')
+echo "BUSINESS_ID=$BUSINESS_ID"
 
-cited audit start <BIZ_ID>
-# ^^^ capture AUDIT_JOB
-cited job watch <AUDIT_JOB>
+# ── Step 2: Scan the website ───────────────────────────────────────────────────
+CRAWL_JOB=$(cited --json business crawl $BUSINESS_ID | jq -r '.job_id')
+cited job watch $CRAWL_JOB
+cited business health $BUSINESS_ID   # view score bars
 
-cited recommend start <AUDIT_JOB>
-# ^^^ capture RECO_JOB
-cited job watch <RECO_JOB>
-cited --json recommend result <RECO_JOB>
-# ^^^ extract a RECOMMENDATION_ID from the results
+# ── Step 3: Create audit template ─────────────────────────────────────────────
+TEMPLATE_ID=$(cited --json audit template create \
+  --name        "E2E Audit Template" \
+  --business    $BUSINESS_ID \
+  --question    "Are we cited when people ask about AI safety?" \
+  --question    "Does our product appear in AI assistant recommendations?" \
+  --question    "Are we mentioned for responsible AI development?" \
+  | jq -r '.id')
+echo "TEMPLATE_ID=$TEMPLATE_ID"
 
-cited solution start <RECOMMENDATION_ID>
-# ^^^ capture SOL_JOB
-cited job watch <SOL_JOB>
+cited audit template get $TEMPLATE_ID   # verify questions
 
-cited hq <BIZ_ID> --full
-cited analytics trends <BIZ_ID>
-cited audit export <AUDIT_JOB> --output e2e-test.pdf
+# ── Step 3b: Refine questions (common — auto-generated questions need tuning) ─
+cited audit template update $TEMPLATE_ID \
+  --question "Are we cited when enterprise buyers ask about AI safety?" \
+  --question "Does Anthropic appear in responsible AI tool recommendations?" \
+  --question "Are we mentioned when developers compare AI platforms?"
 
-cited business delete <BIZ_ID> --yes
-cited auth logout
+cited audit template get $TEMPLATE_ID   # verify updated questions
+
+# ── Step 4: Run the audit ──────────────────────────────────────────────────────
+AUDIT_JOB=$(cited --json audit start $TEMPLATE_ID --business $BUSINESS_ID \
+  | jq -r '.job_id')
+echo "AUDIT_JOB=$AUDIT_JOB"
+cited job watch $AUDIT_JOB
+
+cited audit result $AUDIT_JOB           # view full results
+cited audit list --business $BUSINESS_ID
+
+# ── Step 5: Generate recommendations ──────────────────────────────────────────
+RECO_JOB=$(cited --json recommend start $AUDIT_JOB | jq -r '.job_id')
+echo "RECO_JOB=$RECO_JOB"
+cited job watch $RECO_JOB --type recommendations
+
+cited recommend insights $RECO_JOB      # view insights table
+
+# ── Step 6: Start a solution ───────────────────────────────────────────────────
+SOURCE_ID=$(cited --json recommend result $RECO_JOB \
+  | jq -r '.question_insights[0].question_id')
+echo "SOURCE_ID=$SOURCE_ID"
+
+SOL_JOB=$(cited --json solution start $RECO_JOB \
+  --type   question_insight \
+  --source $SOURCE_ID \
+  | jq -r '.job_id')
+echo "SOL_JOB=$SOL_JOB"
+
+cited job watch $SOL_JOB --type solutions
+# → "View artifacts: https://dev.youcited.com/solutions/$SOL_JOB"
+
+# ── Step 7: HQ dashboard ──────────────────────────────────────────────────────
+cited hq $BUSINESS_ID --full
+cited analytics trends $BUSINESS_ID
+
+# ── Step 8: Cleanup ────────────────────────────────────────────────────────────
+cited audit template delete $TEMPLATE_ID --yes
+cited business delete $BUSINESS_ID --yes
+cited logout
+cited auth status   # Should fail — exit code 2
 ```

--- a/scripts/cleanup_dev.py
+++ b/scripts/cleanup_dev.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""
+cleanup_dev.py — Find and remove test assets from the Cited dev environment.
+
+Lists all businesses (and their audit templates) on the target environment,
+lets you pick which ones to delete, and removes them along with associated
+templates.
+
+Requirements: `cited` CLI installed and authenticated (`cited login` first).
+
+Usage:
+    python3 scripts/cleanup_dev.py              # interactive — prompts before deleting
+    python3 scripts/cleanup_dev.py --dry-run    # just list, don't delete anything
+    python3 scripts/cleanup_dev.py --auto       # auto-delete businesses matching test patterns
+    python3 scripts/cleanup_dev.py --env prod   # target a different environment
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime
+
+# Patterns that identify test businesses (case-insensitive substring match)
+TEST_PATTERNS = [
+    "e2e test",
+    "cli test",
+    "pipeline test",
+    "test corp",
+    "test business",
+    "runbook test",
+]
+
+
+def cited_json(env: str, *args: str) -> dict | list:
+    """Run a cited command with --json and return parsed output."""
+    cmd = ["cited", "--env", env, "--json", *args]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        # Try to parse error JSON, fall back to stderr
+        try:
+            err = json.loads(result.stdout or result.stderr)
+            msg = err.get("message", result.stderr)
+        except (json.JSONDecodeError, TypeError):
+            msg = result.stderr.strip() or result.stdout.strip()
+        print(f"  ✗ Command failed: {' '.join(args)}")
+        print(f"    {msg}")
+        return []
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        print(f"  ✗ Could not parse JSON from: {' '.join(args)}")
+        return []
+
+
+def cited_run(env: str, *args: str) -> bool:
+    """Run a cited command (non-JSON) and return success."""
+    cmd = ["cited", "--env", env, *args]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    return result.returncode == 0
+
+
+def is_test_business(name: str) -> bool:
+    """Check if a business name matches known test patterns."""
+    lower = name.lower()
+    return any(p in lower for p in TEST_PATTERNS)
+
+
+def format_age(created_at: str) -> str:
+    """Return a human-readable age string from an ISO timestamp."""
+    try:
+        created = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+        now = datetime.now(created.tzinfo)
+        delta = now - created
+        if delta.days > 0:
+            return f"{delta.days}d ago"
+        hours = delta.seconds // 3600
+        if hours > 0:
+            return f"{hours}h ago"
+        minutes = delta.seconds // 60
+        return f"{minutes}m ago"
+    except (ValueError, TypeError):
+        return "unknown"
+
+
+def list_businesses(env: str) -> list[dict]:
+    """Fetch all businesses and annotate with test pattern match."""
+    businesses = cited_json(env, "business", "list")
+    if not isinstance(businesses, list):
+        return []
+    return businesses
+
+
+def list_templates(env: str, business_id: str) -> list[dict]:
+    """Fetch audit templates for a business."""
+    templates = cited_json(env, "audit", "template", "list", "--business", business_id)
+    if not isinstance(templates, list):
+        return []
+    return templates
+
+
+def delete_business(env: str, business_id: str, name: str) -> bool:
+    """Delete a business and return success."""
+    ok = cited_run(env, "business", "delete", business_id, "--yes")
+    if ok:
+        print(f"  ✓ Deleted business {business_id[:8]} ({name})")
+    else:
+        print(f"  ✗ Failed to delete business {business_id[:8]} ({name})")
+    return ok
+
+
+def delete_template(env: str, template_id: str, name: str) -> bool:
+    """Delete an audit template and return success."""
+    ok = cited_run(env, "audit", "template", "delete", template_id, "--yes")
+    if ok:
+        print(f"  ✓ Deleted template {template_id[:8]} ({name})")
+    else:
+        print(f"  ✗ Failed to delete template {template_id[:8]} ({name})")
+    return ok
+
+
+def print_business_table(businesses: list[dict]) -> None:
+    """Print a formatted table of businesses."""
+    print(f"\n{'#':>3}  {'ID':8}  {'Test?':5}  {'Age':>8}  Name")
+    print(f"{'─'*3}  {'─'*8}  {'─'*5}  {'─'*8}  {'─'*30}")
+    for i, b in enumerate(businesses, 1):
+        bid = b.get("id", "")[:8]
+        name = b.get("name", "")
+        age = format_age(b.get("created_at", ""))
+        test = "YES" if is_test_business(name) else ""
+        print(f"{i:>3}  {bid}  {test:<5}  {age:>8}  {name}")
+    print()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Clean up test assets from a Cited environment."
+    )
+    parser.add_argument(
+        "--env", default="dev",
+        help="Target environment (default: dev)",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="List assets without deleting anything",
+    )
+    parser.add_argument(
+        "--auto", action="store_true",
+        help="Auto-delete businesses matching test patterns (no prompts)",
+    )
+    args = parser.parse_args()
+
+    env = args.env
+    print(f"Scanning {env} environment...\n")
+
+    # 1. List businesses
+    businesses = list_businesses(env)
+    if not businesses:
+        print("No businesses found.")
+        return
+
+    print_business_table(businesses)
+
+    if args.dry_run:
+        test_count = sum(1 for b in businesses if is_test_business(b.get("name", "")))
+        print(f"Dry run: {test_count} test business(es) would be deleted.")
+        print("Run without --dry-run to delete.")
+        return
+
+    # 2. Determine which businesses to delete
+    to_delete: list[dict] = []
+
+    if args.auto:
+        to_delete = [b for b in businesses if is_test_business(b.get("name", ""))]
+        if not to_delete:
+            print("No businesses match test patterns. Nothing to clean up.")
+            return
+        print(f"Auto mode: {len(to_delete)} business(es) match test patterns.")
+    else:
+        # Interactive mode
+        print("Enter business numbers to delete (comma-separated), 'test' for all")
+        print("test-pattern matches, or 'q' to quit:")
+        choice = input("> ").strip().lower()
+
+        if choice in ("q", "quit", ""):
+            print("Aborted.")
+            return
+        elif choice == "test":
+            to_delete = [b for b in businesses if is_test_business(b.get("name", ""))]
+        else:
+            try:
+                indices = [int(x.strip()) - 1 for x in choice.split(",")]
+                to_delete = [businesses[i] for i in indices if 0 <= i < len(businesses)]
+            except (ValueError, IndexError):
+                print("Invalid input. Aborted.")
+                return
+
+    if not to_delete:
+        print("Nothing selected. Aborted.")
+        return
+
+    # 3. Confirm
+    if not args.auto:
+        print(f"\nWill delete {len(to_delete)} business(es):")
+        for b in to_delete:
+            print(f"  • {b['id'][:8]}  {b.get('name', '')}")
+        confirm = input("\nProceed? [y/N] ").strip().lower()
+        if confirm != "y":
+            print("Aborted.")
+            return
+
+    # 4. Delete templates first, then businesses
+    deleted_templates = 0
+    deleted_businesses = 0
+
+    for b in to_delete:
+        bid = b["id"]
+        name = b.get("name", "")
+        print(f"\n── {name} ({bid[:8]}) ──")
+
+        # Delete associated templates
+        templates = list_templates(env, bid)
+        for t in templates:
+            tid = t.get("id", "")
+            tname = t.get("name", "")
+            if delete_template(env, tid, tname):
+                deleted_templates += 1
+
+        # Delete the business
+        if delete_business(env, bid, name):
+            deleted_businesses += 1
+
+    # 5. Summary
+    print(f"\n{'─'*40}")
+    print(f"Cleanup complete:")
+    print(f"  Businesses deleted: {deleted_businesses}")
+    print(f"  Templates deleted:  {deleted_templates}")
+
+    # 6. Verify
+    remaining = list_businesses(env)
+    print(f"  Businesses remaining: {len(remaining)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cited_cli/api/client.py
+++ b/src/cited_cli/api/client.py
@@ -84,6 +84,10 @@ class CitedClient:
         response = self._client.post(path, **kwargs)
         return self._handle_response(response)
 
+    def put(self, path: str, json: dict[str, Any] | None = None) -> Any:
+        response = self._client.put(path, json=json or {})
+        return self._handle_response(response)
+
     def patch(self, path: str, json: dict[str, Any] | None = None) -> Any:
         response = self._client.patch(path, json=json or {})
         return self._handle_response(response)

--- a/src/cited_cli/api/endpoints.py
+++ b/src/cited_cli/api/endpoints.py
@@ -1,5 +1,9 @@
 # Auth
 LOGIN = "/auth/login"
+CLI_LOGIN = "/auth/cli-login"
+CLI_REGISTER = "/auth/cli-register"
+CLI_VERIFY_EMAIL = "/auth/cli-verify-email"
+CLI_OAUTH_START = "/auth/cli-oauth-start"
 LOGOUT = "/auth/logout"
 ME = "/auth/me"
 
@@ -21,6 +25,10 @@ HEALTH_SCORES_BREAKDOWN = "/businesses/{business_id}/health-scores/breakdown"
 CRAWL_DATA = "/businesses/{business_id}/crawl-data"
 CRAWL_START = "/businesses/{business_id}/crawl"
 CRAWL_CANCEL = "/businesses/{business_id}/crawl/cancel"
+
+# Named Audits (templates)
+NAMED_AUDITS = "/named-audits"
+NAMED_AUDIT = "/named-audits/{named_audit_id}"
 
 # Audit
 AUDIT_START = "/audit/start"

--- a/src/cited_cli/app.py
+++ b/src/cited_cli/app.py
@@ -11,7 +11,8 @@ from cited_cli.api.client import CitedClient
 from cited_cli.commands.agent import agent_app
 from cited_cli.commands.analytics import analytics_app
 from cited_cli.commands.audit import audit_app
-from cited_cli.commands.auth import auth_app
+from cited_cli.commands.named_audit import named_audit_app
+from cited_cli.commands.auth import auth_app, do_login, do_logout, do_register
 from cited_cli.commands.business import business_app
 from cited_cli.commands.config_cmd import config_app
 from cited_cli.commands.hq import hq_app
@@ -29,6 +30,9 @@ app = typer.Typer(
     no_args_is_help=True,
     rich_markup_mode="rich",
 )
+
+# Register nested subcommand groups
+audit_app.add_typer(named_audit_app, name="template")
 
 # Register subcommand groups
 app.add_typer(auth_app, name="auth")
@@ -124,6 +128,45 @@ def status(ctx: typer.Context) -> None:
         raise typer.Exit(ExitCode.ERROR) from e
     finally:
         client.close()
+
+
+@app.command()
+def login(
+    ctx: typer.Context,
+    email: Annotated[str | None, typer.Option(help="Email address")] = None,
+    password: Annotated[
+        str | None, typer.Option(help="Password", hide_input=True)
+    ] = None,
+    provider: Annotated[
+        str | None,
+        typer.Option(help="OAuth provider: google, microsoft, github"),
+    ] = None,
+) -> None:
+    """Log in to Cited. Opens browser by default, or use --email for password login."""
+    do_login(ctx, email, password, provider)
+
+
+@app.command()
+def logout(ctx: typer.Context) -> None:
+    """Log out and clear stored credentials."""
+    do_logout(ctx)
+
+
+@app.command()
+def register(
+    ctx: typer.Context,
+    email: Annotated[str | None, typer.Option(help="Email address")] = None,
+    name: Annotated[str | None, typer.Option(help="Full name")] = None,
+    password: Annotated[
+        str | None, typer.Option(help="Password", hide_input=True)
+    ] = None,
+    provider: Annotated[
+        str | None,
+        typer.Option(help="OAuth provider: google, microsoft, github"),
+    ] = None,
+) -> None:
+    """Register a new Cited account. Opens browser or use --email."""
+    do_register(ctx, email, name, password, provider)
 
 
 def main() -> None:

--- a/src/cited_cli/auth/oauth_server.py
+++ b/src/cited_cli/auth/oauth_server.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import html
+import socket
+import threading
+from functools import partial
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs, urlparse
+
+_SUCCESS_HTML_TEMPLATE = """\
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>Cited CLI</title>
+<style>body{{font-family:system-ui,sans-serif;display:flex;justify-content:center;
+align-items:center;height:100vh;margin:0;background:#f8f9fa;}}
+.card{{text-align:center;padding:2rem;max-width:600px;}}
+.token-section{{margin-top:1.5rem;text-align:left;}}
+.token-box{{background:#f1f5f9;border:1px solid #cbd5e1;border-radius:6px;
+padding:0.75rem;font-family:monospace;font-size:0.8rem;word-break:break-all;
+max-height:4rem;overflow-y:auto;}}
+.copy-btn{{margin-top:0.5rem;padding:0.4rem 1rem;background:#3b82f6;color:#fff;
+border:none;border-radius:4px;cursor:pointer;font-size:0.85rem;}}
+.copy-btn:hover{{background:#2563eb;}}
+summary{{cursor:pointer;color:#64748b;font-size:0.9rem;}}</style></head>
+<body><div class="card">
+<h1 style="color:#22c55e;">&#10003; Authentication successful</h1>
+<p>You can close this tab and return to your terminal.</p>
+<details class="token-section">
+<summary>Terminal not responding? Copy your token manually</summary>
+<p style="font-size:0.85rem;color:#475569;">
+If the CLI didn't detect the login, copy this token and paste it in your terminal.</p>
+<div class="token-box" id="token-text">{token}</div>
+<button class="copy-btn" onclick="
+var t=document.getElementById('token-text').textContent;
+navigator.clipboard.writeText(t).then(function(){{this.textContent='Copied!'}}.bind(this))
+">Copy token</button>
+</details>
+</div></body></html>
+"""
+
+_ERROR_HTML = """\
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>Cited CLI</title>
+<style>body{font-family:system-ui,sans-serif;display:flex;justify-content:center;
+align-items:center;height:100vh;margin:0;background:#f8f9fa;}
+.card{text-align:center;padding:2rem;}</style></head>
+<body><div class="card">
+<h1 style="color:#ef4444;">Authentication failed</h1>
+<p>No token was received. Please try again.</p>
+</div></body></html>
+"""
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class _CallbackHandler(BaseHTTPRequestHandler):
+    def __init__(
+        self, token_event: threading.Event, server_ref: OAuthCallbackServer, *args, **kwargs,
+    ):
+        self._token_event = token_event
+        self._server_ref = server_ref
+        super().__init__(*args, **kwargs)
+
+    def do_GET(self) -> None:  # noqa: N802
+        parsed = urlparse(self.path)
+        if parsed.path != "/callback":
+            self.send_error(404)
+            return
+
+        params = parse_qs(parsed.query)
+        token = params.get("token", [None])[0]
+
+        if token:
+            self._server_ref.token = token
+            success_html = _SUCCESS_HTML_TEMPLATE.format(token=html.escape(token))
+            self._send_html(200, success_html)
+            self._token_event.set()
+        else:
+            self._send_html(400, _ERROR_HTML)
+
+    def _send_html(self, code: int, html: str) -> None:
+        self.send_response(code)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.end_headers()
+        self.wfile.write(html.encode())
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        pass  # Suppress request logging
+
+
+class OAuthCallbackServer:
+    """Temporary localhost server to receive OAuth callback with token."""
+
+    def __init__(self, timeout: float = 120.0) -> None:
+        self.token: str | None = None
+        self.port: int = _find_free_port()
+        self.redirect_uri = f"http://localhost:{self.port}/callback"
+        self._timeout = timeout
+        self._token_event = threading.Event()
+        self._server: HTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        handler = partial(_CallbackHandler, self._token_event, self)
+        self._server = HTTPServer(("127.0.0.1", self.port), handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def wait_for_token(self) -> str | None:
+        self._token_event.wait(timeout=self._timeout)
+        return self.token
+
+    def shutdown(self) -> None:
+        if self._server:
+            self._server.shutdown()
+        if self._thread:
+            self._thread.join(timeout=5)

--- a/src/cited_cli/commands/analytics.py
+++ b/src/cited_cli/commands/analytics.py
@@ -26,7 +26,7 @@ def _get_client(ctx: typer.Context) -> tuple[OutputContext, CitedClient]:
     store = TokenStore()
     token = store.get_token(env)
     if not token:
-        print_error(f"Not logged in to {env}. Run: cited auth login", out)
+        print_error(f"Not logged in to {env}. Run: cited login", out)
         raise typer.Exit(ExitCode.AUTH_ERROR)
 
     return out, CitedClient(base_url=api_url, token=token)

--- a/src/cited_cli/commands/audit.py
+++ b/src/cited_cli/commands/audit.py
@@ -27,7 +27,7 @@ def _get_client(ctx: typer.Context) -> tuple[OutputContext, CitedClient, str]:
     store = TokenStore()
     token = store.get_token(env)
     if not token:
-        print_error(f"Not logged in to {env}. Run: cited auth login", out)
+        print_error(f"Not logged in to {env}. Run: cited login", out)
         raise typer.Exit(ExitCode.AUTH_ERROR)
 
     return out, CitedClient(base_url=api_url, token=token), env
@@ -36,14 +36,27 @@ def _get_client(ctx: typer.Context) -> tuple[OutputContext, CitedClient, str]:
 @audit_app.command("start")
 def audit_start(
     ctx: typer.Context,
-    business_id: Annotated[str, typer.Argument(help="Business ID to audit")],
+    named_audit_id: Annotated[str, typer.Argument(help="Audit template (named audit) ID")],
+    business_id: Annotated[
+        str | None,
+        typer.Option("--business", "-b", help="Business ID override"),
+    ] = None,
+    providers: Annotated[
+        list[str] | None,
+        typer.Option("--provider", help="Citation provider to use (repeatable)"),
+    ] = None,
 ) -> None:
-    """Start a new audit job."""
+    """Start a new audit job from a template."""
     out, client, _ = _get_client(ctx)
     try:
+        payload: dict = {"named_audit_id": named_audit_id}
+        if business_id:
+            payload["business_id"] = business_id
+        if providers:
+            payload["providers"] = providers
         data = client.post(
             endpoints.AUDIT_START,
-            json={"business_id": business_id},
+            json=payload,
             timeout=LONG_TIMEOUT,
         )
         job_id = data.get("job_id", data.get("id", ""))

--- a/src/cited_cli/commands/auth.py
+++ b/src/cited_cli/commands/auth.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 import sys
 from typing import Annotated
 
@@ -9,12 +8,19 @@ import typer
 from cited_cli.api import endpoints
 from cited_cli.api.client import CitedClient
 from cited_cli.auth.store import TokenStore
+from cited_cli.config.constants import FRONTEND_URLS, DEFAULT_ENV
 from cited_cli.config.manager import ConfigManager
 from cited_cli.output.formatter import OutputContext, print_error, print_result, print_success
 from cited_cli.output.tables import render_kv
 from cited_cli.utils.errors import CitedAPIError, ExitCode, handle_api_error
 
 auth_app = typer.Typer(name="auth", help="Authentication commands.")
+
+_VALID_PROVIDERS = ("google", "microsoft", "github")
+
+
+def _is_interactive() -> bool:
+    return sys.stdin.isatty()
 
 
 def _get_ctx(ctx: typer.Context) -> tuple[OutputContext, ConfigManager, str]:
@@ -28,51 +34,19 @@ def _get_ctx(ctx: typer.Context) -> tuple[OutputContext, ConfigManager, str]:
     return out, cfg, env
 
 
-@auth_app.command()
-def login(
-    ctx: typer.Context,
-    email: Annotated[str | None, typer.Option(help="Email address")] = None,
-    password: Annotated[str | None, typer.Option(help="Password", hide_input=True)] = None,
-) -> None:
-    """Log in with email and password."""
-    out, cfg, env = _get_ctx(ctx)
-
-    if not sys.stdin.isatty() and (email is None or password is None):
-        print_error("Non-interactive mode requires --email and --password", out)
-        raise typer.Exit(ExitCode.VALIDATION_ERROR)
-
-    if email is None:
-        email = typer.prompt("Email")
-    if password is None:
-        password = typer.prompt("Password", hide_input=True)
-
-    api_url = cfg.get_api_url(
-        profile=(ctx.obj or {}).get("profile", "default"),
-        env_override=(ctx.obj or {}).get("env_override"),
+def _get_api_url(ctx: typer.Context, cfg: ConfigManager) -> str:
+    obj = ctx.obj or {}
+    return cfg.get_api_url(
+        profile=obj.get("profile", "default"),
+        env_override=obj.get("env_override"),
     )
 
+
+def _password_login(out: OutputContext, api_url: str, env: str, email: str, password: str) -> None:
     client = CitedClient(base_url=api_url)
     try:
-        response = client.post_raw(endpoints.LOGIN, json={"email": email, "password": password})
-        if not response.is_success:
-            body = {}
-            with contextlib.suppress(Exception):
-                body = response.json()
-            msg = body.get("detail", f"Login failed ({response.status_code})")
-            raise CitedAPIError(response.status_code, str(msg))
-
-        # Extract JWT from cookie
-        token = response.cookies.get("advgeo_session")
-        if not token:
-            # Fallback: check Set-Cookie header manually
-            for header_val in response.headers.get_list("set-cookie"):
-                if header_val.startswith("advgeo_session="):
-                    token = header_val.split("=", 1)[1].split(";")[0]
-                    break
-
-        if not token:
-            print_error("Login succeeded but no session token was returned.", out)
-            raise typer.Exit(ExitCode.ERROR)
+        response = client.post(endpoints.CLI_LOGIN, json={"email": email, "password": password})
+        token = response["token"]
 
         store = TokenStore()
         store.save_token(env, token)
@@ -83,9 +57,157 @@ def login(
         client.close()
 
 
-@auth_app.command()
-def logout(ctx: typer.Context) -> None:
-    """Log out and clear stored credentials."""
+def _browser_auth(
+    out: OutputContext, api_url: str, env: str, provider: str | None = None,
+    *, mode: str = "login",
+) -> None:
+    import webbrowser
+
+    from cited_cli.auth.oauth_server import OAuthCallbackServer
+
+    server = OAuthCallbackServer(timeout=120)
+    server.start()
+
+    client = CitedClient(base_url=api_url)
+    try:
+        payload: dict[str, str] = {"redirect_uri": server.redirect_uri, "mode": mode}
+        if provider:
+            payload["provider"] = provider
+
+        response = client.post(endpoints.CLI_OAUTH_START, json=payload)
+        auth_url = response["auth_url"]
+
+        action = "registration" if mode == "register" else "login"
+        label = f"{provider} {action}" if provider else action
+        out.console.print(f"Opening browser for {label}...")
+        if not webbrowser.open(auth_url):
+            out.console.print(
+                f"\nCould not open browser. Visit this URL manually:\n{auth_url}"
+            )
+        out.console.print("[dim]Waiting for authentication...[/dim]")
+
+        token = server.wait_for_token()
+        if not token:
+            # Paste fallback for environments where localhost callback fails
+            if _is_interactive():
+                out.console.print(
+                    "\n[yellow]Browser callback timed out.[/yellow]\n"
+                    "If you completed login in the browser, copy the token shown\n"
+                    "on the success page and paste it below.\n"
+                )
+                pasted = typer.prompt("Paste token (or press Enter to cancel)", default="")
+                if pasted.strip():
+                    token = pasted.strip()
+                else:
+                    print_error("Authentication cancelled.", out)
+                    raise typer.Exit(ExitCode.AUTH_ERROR)
+            else:
+                print_error("Authentication timed out. Please try again.", out)
+                raise typer.Exit(ExitCode.AUTH_ERROR)
+
+        store = TokenStore()
+        store.save_token(env, token)
+        via = f" via {provider}" if provider else ""
+        success_msg = "Registered" if mode == "register" else "Logged in"
+        print_success(f"{success_msg} on {env}{via}", out)
+    except CitedAPIError as e:
+        handle_api_error(e, out.json_mode)
+    finally:
+        server.shutdown()
+        client.close()
+
+
+def _password_register(
+    out: OutputContext, api_url: str, env: str, name: str, email: str, password: str,
+) -> None:
+    from urllib.parse import parse_qs, urlparse
+
+    client = CitedClient(base_url=api_url)
+    try:
+        response = client.post(
+            endpoints.CLI_REGISTER,
+            json={"name": name, "email": email, "password": password},
+        )
+        msg = response["message"]
+    except CitedAPIError as e:
+        handle_api_error(e, out.json_mode)
+        return
+    finally:
+        client.close()
+
+    print_success(f"Account created for {email} on {env}", out)
+    out.console.print(f"[dim]{msg}[/dim]")
+
+    out.console.print("\n[bold]Paste your verification link from the email:[/bold]")
+    verify_url = typer.prompt("Verification URL").strip()
+
+    parsed = urlparse(verify_url)
+    params = parse_qs(parsed.query)
+    token = params.get("token", [None])[0]
+    if not token:
+        print_error(
+            "Could not find token in URL. Run `cited login` after verifying in browser.",
+            out,
+        )
+        raise typer.Exit(1)
+
+    client = CitedClient(base_url=api_url)
+    try:
+        verify_response = client.post(
+            endpoints.CLI_VERIFY_EMAIL,
+            json={"token": token},
+        )
+        jwt = verify_response["token"]
+    except CitedAPIError as e:
+        handle_api_error(e, out.json_mode)
+        return
+    finally:
+        client.close()
+
+    store = TokenStore()
+    store.save_token(env, jwt)
+    print_success(f"Email verified! Logged in as {email}", out)
+
+    frontend_url = FRONTEND_URLS.get(env, FRONTEND_URLS[DEFAULT_ENV])
+    out.console.print(f"[dim]→ Complete your account setup at {frontend_url}/onboarding[/dim]")
+
+
+def do_login(
+    ctx: typer.Context,
+    email: str | None = None,
+    password: str | None = None,
+    provider: str | None = None,
+) -> None:
+    """Shared login logic for both `cited login` and `cited auth login`."""
+    out, cfg, env = _get_ctx(ctx)
+    api_url = _get_api_url(ctx, cfg)
+
+    if provider and provider not in _VALID_PROVIDERS:
+        print_error(
+            f"Invalid provider '{provider}'. "
+            f"Must be one of: {', '.join(_VALID_PROVIDERS)}",
+            out,
+        )
+        raise typer.Exit(ExitCode.VALIDATION_ERROR)
+
+    if email:
+        if password is None:
+            if not _is_interactive():
+                print_error(
+                    "Non-interactive mode requires --email and --password", out
+                )
+                raise typer.Exit(ExitCode.VALIDATION_ERROR)
+            password = typer.prompt("Password", hide_input=True)
+        _password_login(out, api_url, env, email, password)
+    else:
+        # Browser login — works in both TTY and non-TTY contexts.
+        # The browser opens independently and the localhost callback
+        # server receives the token without needing stdin.
+        _browser_auth(out, api_url, env, provider, mode="login")
+
+
+def do_logout(ctx: typer.Context) -> None:
+    """Shared logout logic for both `cited logout` and `cited auth logout`."""
     out, cfg, env = _get_ctx(ctx)
     store = TokenStore()
 
@@ -97,6 +219,84 @@ def logout(ctx: typer.Context) -> None:
     print_success(f"Logged out of {env}", out)
 
 
+def do_register(
+    ctx: typer.Context,
+    email: str | None = None,
+    name: str | None = None,
+    password: str | None = None,
+    provider: str | None = None,
+) -> None:
+    """Shared register logic for both `cited register` and `cited auth register`."""
+    out, cfg, env = _get_ctx(ctx)
+    api_url = _get_api_url(ctx, cfg)
+
+    if provider and provider not in _VALID_PROVIDERS:
+        print_error(
+            f"Invalid provider '{provider}'. "
+            f"Must be one of: {', '.join(_VALID_PROVIDERS)}",
+            out,
+        )
+        raise typer.Exit(ExitCode.VALIDATION_ERROR)
+
+    if email:
+        if name is None:
+            if not _is_interactive():
+                print_error("Non-interactive mode requires --name", out)
+                raise typer.Exit(ExitCode.VALIDATION_ERROR)
+            name = typer.prompt("Full name")
+        if password is None:
+            if not _is_interactive():
+                print_error("Non-interactive mode requires --password", out)
+                raise typer.Exit(ExitCode.VALIDATION_ERROR)
+            password = typer.prompt("Password", hide_input=True)
+            confirm = typer.prompt("Confirm password", hide_input=True)
+            if password != confirm:
+                print_error("Passwords do not match.", out)
+                raise typer.Exit(ExitCode.VALIDATION_ERROR)
+        _password_register(out, api_url, env, name, email, password)
+    else:
+        _browser_auth(out, api_url, env, provider, mode="register")
+
+
+@auth_app.command()
+def login(
+    ctx: typer.Context,
+    email: Annotated[str | None, typer.Option(help="Email address")] = None,
+    password: Annotated[
+        str | None, typer.Option(help="Password", hide_input=True)
+    ] = None,
+    provider: Annotated[
+        str | None,
+        typer.Option(help="OAuth provider: google, microsoft, github"),
+    ] = None,
+) -> None:
+    """Log in to Cited. Opens browser by default, or use --email for password login."""
+    do_login(ctx, email, password, provider)
+
+
+@auth_app.command()
+def logout(ctx: typer.Context) -> None:
+    """Log out and clear stored credentials."""
+    do_logout(ctx)
+
+
+@auth_app.command()
+def register(
+    ctx: typer.Context,
+    email: Annotated[str | None, typer.Option(help="Email address")] = None,
+    name: Annotated[str | None, typer.Option(help="Full name")] = None,
+    password: Annotated[
+        str | None, typer.Option(help="Password", hide_input=True)
+    ] = None,
+    provider: Annotated[
+        str | None,
+        typer.Option(help="OAuth provider: google, microsoft, github"),
+    ] = None,
+) -> None:
+    """Register a new Cited account. Opens browser or use --email."""
+    do_register(ctx, email, name, password, provider)
+
+
 @auth_app.command()
 def status(ctx: typer.Context) -> None:
     """Show current authentication status and user info."""
@@ -105,31 +305,35 @@ def status(ctx: typer.Context) -> None:
     token = store.get_token(env)
 
     if not token:
-        print_error(f"Not logged in to {env}. Run: cited auth login", out)
+        print_error(f"Not logged in to {env}. Run: cited login", out)
         raise typer.Exit(ExitCode.AUTH_ERROR)
 
-    api_url = cfg.get_api_url(
-        profile=(ctx.obj or {}).get("profile", "default"),
-        env_override=(ctx.obj or {}).get("env_override"),
-    )
+    api_url = _get_api_url(ctx, cfg)
     client = CitedClient(base_url=api_url, token=token)
     try:
         user = client.get(endpoints.ME)
+        onboarding_completed = user.get("onboarding_completed", False)
         data = {
             "environment": env,
             "email": user.get("email", ""),
             "name": user.get("name", user.get("full_name", "")),
             "plan": user.get("plan", user.get("subscription_tier", "")),
+            "onboarding_completed": onboarding_completed,
         }
         print_result(
             data,
             out,
             human_formatter=lambda d, c: render_kv("Auth Status", d, c),
         )
+        if not onboarding_completed and not out.json_mode:
+            frontend_url = FRONTEND_URLS.get(env, FRONTEND_URLS[DEFAULT_ENV])
+            out.console.print(
+                f"[yellow]→ Account setup incomplete. Visit {frontend_url}/onboarding to finish.[/yellow]"
+            )
     except CitedAPIError as e:
         if e.status_code in (401, 403):
             store.delete_token(env)
-            print_error("Session expired. Run: cited auth login", out)
+            print_error("Session expired. Run: cited login", out)
             raise typer.Exit(ExitCode.AUTH_ERROR) from e
         handle_api_error(e, out.json_mode)
     finally:

--- a/src/cited_cli/commands/business.py
+++ b/src/cited_cli/commands/business.py
@@ -27,7 +27,7 @@ def _get_client(ctx: typer.Context) -> tuple[OutputContext, CitedClient, str]:
     store = TokenStore()
     token = store.get_token(env)
     if not token:
-        print_error(f"Not logged in to {env}. Run: cited auth login", out)
+        print_error(f"Not logged in to {env}. Run: cited login", out)
         raise typer.Exit(ExitCode.AUTH_ERROR)
 
     return out, CitedClient(base_url=api_url, token=token), env
@@ -93,12 +93,13 @@ def business_create(
     ctx: typer.Context,
     name: Annotated[str, typer.Option(help="Business name")],
     website: Annotated[str, typer.Option(help="Business website URL")],
+    description: Annotated[str, typer.Option(help="Business description (min 50 chars)")],
     industry: Annotated[str | None, typer.Option(help="Industry")] = None,
 ) -> None:
     """Create a new business."""
     out, client, _ = _get_client(ctx)
     try:
-        payload: dict[str, str] = {"name": name, "website": website}
+        payload: dict[str, str] = {"name": name, "website": website, "description": description}
         if industry:
             payload["industry"] = industry
         data = client.post(endpoints.BUSINESSES, json=payload)

--- a/src/cited_cli/commands/hq.py
+++ b/src/cited_cli/commands/hq.py
@@ -27,7 +27,7 @@ def _get_client(ctx: typer.Context) -> tuple[OutputContext, CitedClient]:
     store = TokenStore()
     token = store.get_token(env)
     if not token:
-        print_error(f"Not logged in to {env}. Run: cited auth login", out)
+        print_error(f"Not logged in to {env}. Run: cited login", out)
         raise typer.Exit(ExitCode.AUTH_ERROR)
 
     return out, CitedClient(base_url=api_url, token=token)

--- a/src/cited_cli/commands/job.py
+++ b/src/cited_cli/commands/job.py
@@ -26,7 +26,7 @@ def _get_client(ctx: typer.Context) -> tuple[OutputContext, CitedClient]:
     store = TokenStore()
     token = store.get_token(env)
     if not token:
-        print_error(f"Not logged in to {env}. Run: cited auth login", out)
+        print_error(f"Not logged in to {env}. Run: cited login", out)
         raise typer.Exit(ExitCode.AUTH_ERROR)
 
     return out, CitedClient(base_url=api_url, token=token)

--- a/src/cited_cli/commands/named_audit.py
+++ b/src/cited_cli/commands/named_audit.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+from rich.console import Console
+
+from cited_cli.api import endpoints
+from cited_cli.api.client import CitedClient
+from cited_cli.auth.store import TokenStore
+from cited_cli.config.manager import ConfigManager
+from cited_cli.output.formatter import OutputContext, print_error, print_result, print_success
+from cited_cli.output.tables import render_kv, render_table
+from cited_cli.utils.errors import CitedAPIError, ExitCode, handle_api_error
+
+named_audit_app = typer.Typer(name="template", help="Manage audit templates.")
+
+
+def _get_client(ctx: typer.Context) -> tuple[OutputContext, CitedClient]:
+    obj = ctx.obj or {}
+    out: OutputContext = obj.get("output", OutputContext())
+    cfg: ConfigManager = obj.get("config", ConfigManager())
+    profile = obj.get("profile", "default")
+    env = cfg.get_environment(profile, obj.get("env_override"))
+    api_url = cfg.get_api_url(profile, obj.get("env_override"))
+
+    store = TokenStore()
+    token = store.get_token(env)
+    if not token:
+        print_error(f"Not logged in to {env}. Run: cited login", out)
+        raise typer.Exit(ExitCode.AUTH_ERROR)
+
+    return out, CitedClient(base_url=api_url, token=token)
+
+
+@named_audit_app.command("list")
+def template_list(
+    ctx: typer.Context,
+    business_id: Annotated[
+        str | None,
+        typer.Option("--business", "-b", help="Filter by business ID"),
+    ] = None,
+) -> None:
+    """List audit templates."""
+    out, client = _get_client(ctx)
+    try:
+        params = {}
+        if business_id:
+            params["business_id"] = business_id
+        data = client.get(endpoints.NAMED_AUDITS, params=params or None)
+        templates = data if isinstance(data, list) else data.get("named_audits", data.get("items", []))
+
+        def _human(d: object, console: Console) -> None:
+            items = d if isinstance(d, list) else []
+            rows = []
+            for t in items:
+                questions = t.get("questions", [])
+                rows.append([
+                    t.get("id", "")[:8],
+                    t.get("name", ""),
+                    t.get("business_name", t.get("business_id", "")),
+                    str(len(questions)),
+                    t.get("created_at", "")[:19] if t.get("created_at") else "",
+                ])
+            render_table(
+                "Audit Templates",
+                ["ID", "Name", "Business", "Questions", "Created"],
+                rows,
+                console,
+            )
+
+        print_result(templates, out, human_formatter=_human)
+    except CitedAPIError as e:
+        handle_api_error(e, out.json_mode)
+    finally:
+        client.close()
+
+
+@named_audit_app.command("get")
+def template_get(
+    ctx: typer.Context,
+    named_audit_id: Annotated[str, typer.Argument(help="Audit template ID")],
+) -> None:
+    """Get audit template details."""
+    out, client = _get_client(ctx)
+    try:
+        path = endpoints.NAMED_AUDIT.format(named_audit_id=named_audit_id)
+        data = client.get(path)
+
+        def _human(d: object, console: Console) -> None:
+            if not isinstance(d, dict):
+                console.print(d)
+                return
+            questions = d.pop("questions", [])
+            render_kv("Audit Template", d, console)
+            if questions:
+                console.print("\n[bold]Questions:[/bold]")
+                for i, q in enumerate(questions, 1):
+                    text = q.get("question", q) if isinstance(q, dict) else q
+                    console.print(f"  {i}. {text}")
+
+        print_result(data, out, human_formatter=_human)
+    except CitedAPIError as e:
+        handle_api_error(e, out.json_mode)
+    finally:
+        client.close()
+
+
+@named_audit_app.command("create")
+def template_create(
+    ctx: typer.Context,
+    name: Annotated[str, typer.Option("--name", "-n", help="Template name")],
+    business_id: Annotated[str, typer.Option("--business", "-b", help="Business ID")],
+    description: Annotated[
+        str | None, typer.Option("--description", "-d", help="Template description")
+    ] = None,
+    questions: Annotated[
+        list[str] | None,
+        typer.Option("--question", "-q", help="Question to include (repeatable)"),
+    ] = None,
+) -> None:
+    """Create a new audit template."""
+    out, client = _get_client(ctx)
+    try:
+        payload: dict = {
+            "name": name,
+            "business_id": business_id,
+        }
+        if description:
+            payload["description"] = description
+        if questions:
+            payload["questions"] = [{"question": q} for q in questions]
+
+        data = client.post(endpoints.NAMED_AUDITS, json=payload)
+        template_id = data.get("id", "")
+        template_name = data.get("name", name)
+        print_result(data, out, human_formatter=lambda d, c: render_kv("Template Created", d, c))
+        if not out.json_mode and template_id:
+            out.console.print(
+                f"\nTemplate ID: [bold]{template_id}[/bold]"
+                f"\nRun audit:   [bold]cited audit start {template_id} --business {business_id}[/bold]"
+            )
+    except CitedAPIError as e:
+        handle_api_error(e, out.json_mode)
+    finally:
+        client.close()
+
+
+@named_audit_app.command("update")
+def template_update(
+    ctx: typer.Context,
+    named_audit_id: Annotated[str, typer.Argument(help="Audit template ID to update")],
+    name: Annotated[
+        str | None, typer.Option("--name", "-n", help="New template name")
+    ] = None,
+    description: Annotated[
+        str | None, typer.Option("--description", "-d", help="New description")
+    ] = None,
+    questions: Annotated[
+        list[str] | None,
+        typer.Option("--question", "-q", help="Replacement question (repeatable — replaces all existing questions)"),
+    ] = None,
+) -> None:
+    """Update an audit template's name, description, or questions.
+
+    When --question flags are provided, they replace ALL existing questions.
+    Omit --question to keep existing questions unchanged.
+    """
+    out, client = _get_client(ctx)
+    try:
+        payload: dict = {}
+        if name is not None:
+            payload["name"] = name
+        if description is not None:
+            payload["description"] = description
+        if questions is not None:
+            payload["questions"] = [{"question": q} for q in questions]
+
+        if not payload:
+            print_error("Nothing to update. Provide --name, --description, or --question.", out)
+            raise typer.Exit(ExitCode.VALIDATION_ERROR)
+
+        path = endpoints.NAMED_AUDIT.format(named_audit_id=named_audit_id)
+        data = client.put(path, json=payload)
+
+        def _human(d: object, console: Console) -> None:
+            if not isinstance(d, dict):
+                console.print(d)
+                return
+            questions_list = d.pop("questions", [])
+            render_kv("Template Updated", d, console)
+            if questions_list:
+                console.print("\n[bold]Questions:[/bold]")
+                for i, q in enumerate(questions_list, 1):
+                    text = q.get("question", q) if isinstance(q, dict) else q
+                    console.print(f"  {i}. {text}")
+
+        print_result(data, out, human_formatter=_human)
+    except CitedAPIError as e:
+        handle_api_error(e, out.json_mode)
+    finally:
+        client.close()
+
+
+@named_audit_app.command("delete")
+def template_delete(
+    ctx: typer.Context,
+    named_audit_id: Annotated[str, typer.Argument(help="Audit template ID to delete")],
+    yes: Annotated[bool, typer.Option("--yes", "-y", help="Skip confirmation")] = False,
+) -> None:
+    """Delete an audit template."""
+    out, client = _get_client(ctx)
+    try:
+        if not yes:
+            confirmed = typer.confirm(f"Delete template {named_audit_id}?")
+            if not confirmed:
+                raise typer.Abort()
+
+        path = endpoints.NAMED_AUDIT.format(named_audit_id=named_audit_id)
+        client.delete(path)
+        print_success(f"Template {named_audit_id} deleted.", out)
+    except CitedAPIError as e:
+        handle_api_error(e, out.json_mode)
+    finally:
+        client.close()

--- a/src/cited_cli/commands/recommend.py
+++ b/src/cited_cli/commands/recommend.py
@@ -27,7 +27,7 @@ def _get_client(ctx: typer.Context) -> tuple[OutputContext, CitedClient]:
     store = TokenStore()
     token = store.get_token(env)
     if not token:
-        print_error(f"Not logged in to {env}. Run: cited auth login", out)
+        print_error(f"Not logged in to {env}. Run: cited login", out)
         raise typer.Exit(ExitCode.AUTH_ERROR)
 
     return out, CitedClient(base_url=api_url, token=token)
@@ -95,6 +95,74 @@ def recommend_result(
         path = endpoints.RECOMMEND_RESULT.format(job_id=job_id)
         data = client.get(path)
         print_result(data, out)
+    except CitedAPIError as e:
+        handle_api_error(e, out.json_mode)
+    finally:
+        client.close()
+
+
+@recommend_app.command("insights")
+def recommend_insights(
+    ctx: typer.Context,
+    job_id: Annotated[str, typer.Argument(help="Recommendation job ID")],
+) -> None:
+    """List solution-ready insights from a recommendation job."""
+    out, client = _get_client(ctx)
+    try:
+        path = endpoints.RECOMMEND_RESULT.format(job_id=job_id)
+        data = client.get(path)
+
+        def _human(d: object, console: Console) -> None:
+            if not isinstance(d, dict):
+                console.print(d)
+                return
+            rows = []
+
+            # question_insights: id=question_id, desc=question_text
+            for item in d.get("question_insights", []):
+                if not isinstance(item, dict):
+                    continue
+                source_id   = item.get("question_id", item.get("id", ""))
+                description = item.get("question_text", item.get("question", ""))
+                rows.append([str(len(rows) + 1), "question_insight", source_id, description[:60]])
+
+            # head_to_head_comparisons: id=competitor_domain
+            for item in d.get("head_to_head_comparisons", d.get("head_to_head", [])):
+                if not isinstance(item, dict):
+                    continue
+                source_id   = item.get("competitor_domain", item.get("id", ""))
+                description = item.get("competitor_domain", item.get("description", ""))
+                rows.append([str(len(rows) + 1), "head_to_head", source_id, description[:60]])
+
+            # strengthening_tips: id=category (no uuid), desc=title
+            for item in d.get("strengthening_tips", []):
+                if not isinstance(item, dict):
+                    continue
+                source_id   = item.get("category", item.get("id", item.get("source_id", "")))
+                description = item.get("title", item.get("description", ""))
+                rows.append([str(len(rows) + 1), "strengthening_tip", source_id, description[:60]])
+
+            # priority_actions: id=id or category
+            for item in d.get("priority_actions", []):
+                if not isinstance(item, dict):
+                    continue
+                source_id   = item.get("id", item.get("category", item.get("source_id", "")))
+                description = item.get("title", item.get("description", item.get("action", "")))
+                rows.append([str(len(rows) + 1), "priority_action", source_id, description[:60]])
+
+            render_table(
+                "Available Insights",
+                ["#", "Type", "Source ID", "Description"],
+                rows,
+                console,
+            )
+            if rows:
+                console.print(
+                    "\nRun a solution: [bold]cited solution start "
+                    f"{job_id} --type <type> --source <source_id>[/bold]"
+                )
+
+        print_result(data, out, human_formatter=_human)
     except CitedAPIError as e:
         handle_api_error(e, out.json_mode)
     finally:

--- a/src/cited_cli/commands/solution.py
+++ b/src/cited_cli/commands/solution.py
@@ -16,7 +16,7 @@ from cited_cli.utils.errors import CitedAPIError, ExitCode, handle_api_error
 solution_app = typer.Typer(name="solution", help="Generate and manage content solutions.")
 
 
-def _get_client(ctx: typer.Context) -> tuple[OutputContext, CitedClient]:
+def _get_client(ctx: typer.Context) -> tuple[OutputContext, CitedClient, str]:
     obj = ctx.obj or {}
     out: OutputContext = obj.get("output", OutputContext())
     cfg: ConfigManager = obj.get("config", ConfigManager())
@@ -27,32 +27,50 @@ def _get_client(ctx: typer.Context) -> tuple[OutputContext, CitedClient]:
     store = TokenStore()
     token = store.get_token(env)
     if not token:
-        print_error(f"Not logged in to {env}. Run: cited auth login", out)
+        print_error(f"Not logged in to {env}. Run: cited login", out)
         raise typer.Exit(ExitCode.AUTH_ERROR)
 
-    return out, CitedClient(base_url=api_url, token=token)
+    return out, CitedClient(base_url=api_url, token=token), env
 
 
 @solution_app.command("start")
 def solution_start(
     ctx: typer.Context,
-    recommendation_id: Annotated[
+    recommendation_job_id: Annotated[
         str,
-        typer.Argument(help="Recommendation ID to generate solution from"),
+        typer.Argument(help="Recommendation job ID"),
+    ],
+    source_type: Annotated[
+        str,
+        typer.Option(
+            "--type", "-t",
+            help="Source type: question_insight, head_to_head, strengthening_tip, priority_action",
+        ),
+    ],
+    source_id: Annotated[
+        str,
+        typer.Option("--source", "-s", help="Source ID from 'cited recommend insights'"),
     ],
 ) -> None:
-    """Generate a content solution from a recommendation."""
-    out, client = _get_client(ctx)
+    """Generate a content solution from a recommendation insight."""
+    out, client, env = _get_client(ctx)
     try:
         data = client.post(
-            endpoints.SOLUTION_CREATE,
-            json={"recommendation_id": recommendation_id},
+            endpoints.SOLUTION_REQUEST,
+            json={
+                "recommendation_job_id": recommendation_job_id,
+                "source_type": source_type,
+                "source_id": source_id,
+            },
             timeout=LONG_TIMEOUT,
         )
         job_id = data.get("job_id", data.get("id", ""))
         print_result(data, out, human_formatter=lambda d, c: render_kv("Solution Started", d, c))
-        if not out.json_mode and job_id:
-            out.console.print(f"\nTrack progress: [bold]cited job watch {job_id}[/bold]")
+        if not out.json_mode:
+            if job_id:
+                out.console.print(f"\nTrack progress: [bold]cited job watch {job_id}[/bold]")
+                web_base = f"https://{env}.youcited.com" if env != "prod" else "https://youcited.com"
+                out.console.print(f"View artifacts: [bold]{web_base}/solutions/{job_id}[/bold]")
     except CitedAPIError as e:
         handle_api_error(e, out.json_mode)
     finally:
@@ -65,7 +83,7 @@ def solution_status(
     job_id: Annotated[str, typer.Argument(help="Solution job ID")],
 ) -> None:
     """Check solution job status."""
-    out, client = _get_client(ctx)
+    out, client, _ = _get_client(ctx)
     try:
         path = endpoints.SOLUTION_STATUS.format(job_id=job_id)
         data = client.get(path)
@@ -82,7 +100,7 @@ def solution_result(
     job_id: Annotated[str, typer.Argument(help="Solution job ID")],
 ) -> None:
     """Get solution results."""
-    out, client = _get_client(ctx)
+    out, client, _ = _get_client(ctx)
     try:
         path = endpoints.SOLUTION_RESULT.format(job_id=job_id)
         data = client.get(path)
@@ -102,7 +120,7 @@ def solution_list(
     ] = None,
 ) -> None:
     """List solution history."""
-    out, client = _get_client(ctx)
+    out, client, _ = _get_client(ctx)
     try:
         params = {}
         if business_id:

--- a/src/cited_cli/config/constants.py
+++ b/src/cited_cli/config/constants.py
@@ -6,6 +6,12 @@ ENVIRONMENTS: dict[str, str] = {
     "local": "http://localhost:8000",
 }
 
+FRONTEND_URLS: dict[str, str] = {
+    "prod": "https://app.youcited.com",
+    "dev": "https://dev.youcited.com",
+    "local": "http://localhost:3000",
+}
+
 DEFAULT_ENV = "prod"
 CONFIG_DIR = Path.home() / ".cited"
 CONFIG_FILE = CONFIG_DIR / "config.toml"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,43 +1,377 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import MagicMock, patch
+import threading
+import urllib.request
 
 import httpx
-import pytest
+import respx
 
 
-def test_auth_status_not_logged_in(runner, cli_app, tmp_path, monkeypatch):
+def _setup_tmp_config(tmp_path, monkeypatch):
     config_dir = tmp_path / ".cited"
     config_file = config_dir / "config.toml"
     creds_file = config_dir / "credentials.json"
     monkeypatch.setattr("cited_cli.config.constants.CONFIG_DIR", config_dir)
     monkeypatch.setattr("cited_cli.config.constants.CONFIG_FILE", config_file)
     monkeypatch.setattr("cited_cli.config.constants.CREDENTIALS_FILE", creds_file)
+    # Also patch the already-imported references in store.py
+    monkeypatch.setattr("cited_cli.auth.store.CONFIG_DIR", config_dir)
+    monkeypatch.setattr("cited_cli.auth.store.CREDENTIALS_FILE", creds_file)
+    # Force file-based credential storage (no keyring) so we can verify
+    monkeypatch.setattr("cited_cli.auth.store.TokenStore._has_keyring", lambda self: False)
+    return config_dir, creds_file
 
+
+def test_auth_status_not_logged_in(runner, cli_app, tmp_path, monkeypatch):
+    _setup_tmp_config(tmp_path, monkeypatch)
     result = runner.invoke(cli_app, ["auth", "status"])
     assert result.exit_code != 0
 
 
 def test_auth_logout_not_logged_in(runner, cli_app, tmp_path, monkeypatch):
-    config_dir = tmp_path / ".cited"
-    config_file = config_dir / "config.toml"
-    creds_file = config_dir / "credentials.json"
-    monkeypatch.setattr("cited_cli.config.constants.CONFIG_DIR", config_dir)
-    monkeypatch.setattr("cited_cli.config.constants.CONFIG_FILE", config_file)
-    monkeypatch.setattr("cited_cli.config.constants.CREDENTIALS_FILE", creds_file)
-
+    _setup_tmp_config(tmp_path, monkeypatch)
     result = runner.invoke(cli_app, ["auth", "logout"])
     assert result.exit_code != 0
 
 
 def test_auth_token_not_logged_in(runner, cli_app, tmp_path, monkeypatch):
-    config_dir = tmp_path / ".cited"
-    config_file = config_dir / "config.toml"
-    creds_file = config_dir / "credentials.json"
-    monkeypatch.setattr("cited_cli.config.constants.CONFIG_DIR", config_dir)
-    monkeypatch.setattr("cited_cli.config.constants.CONFIG_FILE", config_file)
-    monkeypatch.setattr("cited_cli.config.constants.CREDENTIALS_FILE", creds_file)
-
+    _setup_tmp_config(tmp_path, monkeypatch)
     result = runner.invoke(cli_app, ["auth", "token"])
     assert result.exit_code != 0
+
+
+@respx.mock
+def test_login_password_flow(runner, cli_app, tmp_path, monkeypatch):
+    """Password login via --email/--password calls /auth/cli-login and stores token."""
+    _, creds_file = _setup_tmp_config(tmp_path, monkeypatch)
+
+    respx.post("https://api.youcited.com/auth/cli-login").mock(
+        return_value=httpx.Response(200, json={"token": "fake-jwt-token"})
+    )
+
+    result = runner.invoke(
+        cli_app,
+        ["--env", "prod", "auth", "login", "--email", "user@example.com", "--password", "secret"],
+    )
+    assert result.exit_code == 0
+    assert "Logged in" in result.output
+
+    # Verify token was stored
+    creds = json.loads(creds_file.read_text())
+    assert creds["prod"] == "fake-jwt-token"
+
+
+@respx.mock
+def test_login_browser_flow(runner, cli_app, tmp_path, monkeypatch):
+    """Browser login starts OAuth server, opens browser, receives token via callback."""
+    _, creds_file = _setup_tmp_config(tmp_path, monkeypatch)
+
+    # Capture the redirect_uri from the request so we can send a token to it
+    captured_redirect_uri = {}
+
+    def mock_oauth_start(request):
+        body = json.loads(request.content)
+        captured_redirect_uri["uri"] = body["redirect_uri"]
+        return httpx.Response(200, json={"auth_url": "https://accounts.google.com/auth"})
+
+    respx.post("https://api.youcited.com/auth/cli-oauth-start").mock(
+        side_effect=mock_oauth_start
+    )
+
+    # Mock webbrowser.open to instead send a token to the callback server
+    def fake_browser_open(url):
+        # Give the server a moment, then send the token callback
+        def send_callback():
+            uri = captured_redirect_uri["uri"]
+            callback_url = f"{uri}?token=browser-jwt-token"
+            urllib.request.urlopen(callback_url, timeout=5)  # noqa: S310
+
+        threading.Thread(target=send_callback, daemon=True).start()
+        return True
+
+    monkeypatch.setattr("webbrowser.open", fake_browser_open)
+
+    result = runner.invoke(
+        cli_app,
+        ["--env", "prod", "auth", "login", "--provider", "google"],
+        input=None,
+    )
+    assert result.exit_code == 0
+    assert "Logged in" in result.output
+    assert "google" in result.output
+
+    creds = json.loads(creds_file.read_text())
+    assert creds["prod"] == "browser-jwt-token"
+
+
+def test_login_invalid_provider(runner, cli_app, tmp_path, monkeypatch):
+    """Invalid provider name should exit with validation error."""
+    _setup_tmp_config(tmp_path, monkeypatch)
+
+    result = runner.invoke(
+        cli_app,
+        ["auth", "login", "--provider", "facebook"],
+    )
+    assert result.exit_code != 0
+    assert "Invalid provider" in result.output
+
+
+def test_login_non_interactive_email_requires_password(runner, cli_app, tmp_path, monkeypatch):
+    """Non-TTY with --email but no --password should fail with a helpful error."""
+    _setup_tmp_config(tmp_path, monkeypatch)
+    monkeypatch.setattr("cited_cli.commands.auth._is_interactive", lambda: False)
+
+    result = runner.invoke(cli_app, ["auth", "login", "--email", "user@example.com"])
+    assert result.exit_code != 0
+    assert "Non-interactive" in result.output
+
+
+# --- Top-level login/logout tests ---
+
+
+@respx.mock
+def test_top_level_login_password(runner, cli_app, tmp_path, monkeypatch):
+    """Top-level `cited login --email ...` should work identically to `cited auth login`."""
+    _, creds_file = _setup_tmp_config(tmp_path, monkeypatch)
+
+    respx.post("https://api.youcited.com/auth/cli-login").mock(
+        return_value=httpx.Response(200, json={"token": "top-level-jwt"})
+    )
+
+    result = runner.invoke(
+        cli_app,
+        ["--env", "prod", "login", "--email", "user@example.com", "--password", "secret"],
+    )
+    assert result.exit_code == 0
+    assert "Logged in" in result.output
+
+    creds = json.loads(creds_file.read_text())
+    assert creds["prod"] == "top-level-jwt"
+
+
+@respx.mock
+def test_top_level_logout(runner, cli_app, tmp_path, monkeypatch):
+    """Top-level `cited logout` clears stored token."""
+    config_dir, creds_file = _setup_tmp_config(tmp_path, monkeypatch)
+
+    # Pre-store a token
+    config_dir.mkdir(parents=True, exist_ok=True)
+    creds_file.write_text(json.dumps({"prod": "some-token"}))
+
+    result = runner.invoke(cli_app, ["--env", "prod", "logout"])
+    assert result.exit_code == 0
+    assert "Logged out" in result.output
+
+    creds = json.loads(creds_file.read_text())
+    assert "prod" not in creds
+
+
+# --- Register tests ---
+
+
+_FAKE_USER = {
+    "id": "user-123",
+    "name": "Test User",
+    "email": "new@example.com",
+    "auth_provider": "email",
+    "email_verified": True,
+    "has_password": True,
+    "created_at": "2026-01-01T00:00:00Z",
+    "avatar_url": None,
+    "business_name": None,
+    "business_website": None,
+    "industry": None,
+    "business_description": None,
+    "onboarding_completed": False,
+    "subscription_tier": "growth",
+    "subscription_status": None,
+    "cancel_at_period_end": None,
+    "subscription_period_end": None,
+    "subscription_canceled_at": None,
+    "plan_limits": None,
+    "role": "user",
+    "agency_owner_id": None,
+    "is_agency_owner": False,
+    "active_agency_context_id": None,
+    "active_agency_permission": None,
+    "available_agencies": None,
+    "owner_subscription_status": None,
+    "is_impersonating": False,
+    "impersonating_user_id": None,
+    "impersonating_user_email": None,
+    "impersonating_user_name": None,
+    "real_admin_id": None,
+    "pending_invitations_count": 0,
+}
+
+
+@respx.mock
+def test_register_password_flow(runner, cli_app, tmp_path, monkeypatch):
+    """Password registration calls /auth/cli-register (no token), prompts for verification URL, then calls /auth/cli-verify-email and stores token."""
+    _, creds_file = _setup_tmp_config(tmp_path, monkeypatch)
+
+    respx.post("https://api.youcited.com/auth/cli-register").mock(
+        return_value=httpx.Response(
+            201, json={"message": "Verification email sent. Check your inbox to complete registration."}
+        )
+    )
+    respx.post("https://api.youcited.com/auth/cli-verify-email").mock(
+        return_value=httpx.Response(
+            200, json={"token": "register-jwt-token", "user": _FAKE_USER}
+        )
+    )
+
+    fake_verify_url = "https://app.youcited.com/complete-registration?token=fake-verification-token-abc123xyz"
+
+    result = runner.invoke(
+        cli_app,
+        [
+            "--env", "prod", "auth", "register",
+            "--email", "new@example.com",
+            "--name", "Test User",
+            "--password", "Secret1234",
+        ],
+        input=f"{fake_verify_url}\n",
+    )
+    assert result.exit_code == 0, result.output
+    assert "Account created" in result.output
+    assert "Email verified" in result.output
+
+    creds = json.loads(creds_file.read_text())
+    assert creds["prod"] == "register-jwt-token"
+
+
+@respx.mock
+def test_top_level_register(runner, cli_app, tmp_path, monkeypatch):
+    """Top-level `cited register --email ...` should work identically to `cited auth register`."""
+    _, creds_file = _setup_tmp_config(tmp_path, monkeypatch)
+
+    respx.post("https://api.youcited.com/auth/cli-register").mock(
+        return_value=httpx.Response(
+            201, json={"message": "Verification email sent. Check your inbox to complete registration."}
+        )
+    )
+    respx.post("https://api.youcited.com/auth/cli-verify-email").mock(
+        return_value=httpx.Response(
+            200, json={"token": "top-register-jwt", "user": _FAKE_USER}
+        )
+    )
+
+    fake_verify_url = "https://app.youcited.com/complete-registration?token=fake-verification-token-abc123xyz"
+
+    result = runner.invoke(
+        cli_app,
+        [
+            "--env", "prod", "register",
+            "--email", "new@example.com",
+            "--name", "Test User",
+            "--password", "Secret1234",
+        ],
+        input=f"{fake_verify_url}\n",
+    )
+    assert result.exit_code == 0, result.output
+    assert "Account created" in result.output
+    assert "Email verified" in result.output
+
+    creds = json.loads(creds_file.read_text())
+    assert creds["prod"] == "top-register-jwt"
+
+
+@respx.mock
+def test_register_browser_flow(runner, cli_app, tmp_path, monkeypatch):
+    """Browser registration sends mode=register in cli-oauth-start payload."""
+    _, creds_file = _setup_tmp_config(tmp_path, monkeypatch)
+
+    captured_payload = {}
+
+    def mock_oauth_start(request):
+        body = json.loads(request.content)
+        captured_payload.update(body)
+        return httpx.Response(200, json={"auth_url": "https://accounts.google.com/auth"})
+
+    respx.post("https://api.youcited.com/auth/cli-oauth-start").mock(
+        side_effect=mock_oauth_start
+    )
+
+    def fake_browser_open(url):
+        def send_callback():
+            uri = captured_payload["redirect_uri"]
+            callback_url = f"{uri}?token=register-browser-jwt"
+            urllib.request.urlopen(callback_url, timeout=5)  # noqa: S310
+
+        threading.Thread(target=send_callback, daemon=True).start()
+        return True
+
+    monkeypatch.setattr("webbrowser.open", fake_browser_open)
+
+    result = runner.invoke(
+        cli_app,
+        ["--env", "prod", "auth", "register", "--provider", "google"],
+        input=None,
+    )
+    assert result.exit_code == 0
+    assert "Registered" in result.output
+    assert captured_payload.get("mode") == "register"
+
+    creds = json.loads(creds_file.read_text())
+    assert creds["prod"] == "register-browser-jwt"
+
+
+def test_register_invalid_provider(runner, cli_app, tmp_path, monkeypatch):
+    """Invalid provider name should exit with validation error."""
+    _setup_tmp_config(tmp_path, monkeypatch)
+
+    result = runner.invoke(
+        cli_app,
+        ["auth", "register", "--provider", "facebook"],
+    )
+    assert result.exit_code != 0
+    assert "Invalid provider" in result.output
+
+
+def test_register_password_mismatch(runner, cli_app, tmp_path, monkeypatch):
+    """Interactive prompt with mismatched passwords should exit with validation error."""
+    _setup_tmp_config(tmp_path, monkeypatch)
+    monkeypatch.setattr("cited_cli.commands.auth._is_interactive", lambda: True)
+
+    result = runner.invoke(
+        cli_app,
+        ["auth", "register", "--email", "new@example.com", "--name", "Test User"],
+        input="Secret1234\nDifferent1234\n",
+    )
+    assert result.exit_code != 0
+    assert "do not match" in result.output.lower() or "Passwords" in result.output
+
+
+@respx.mock
+def test_paste_fallback(runner, cli_app, tmp_path, monkeypatch):
+    """When browser callback times out, user can paste token manually."""
+    _, creds_file = _setup_tmp_config(tmp_path, monkeypatch)
+
+    respx.post("https://api.youcited.com/auth/cli-oauth-start").mock(
+        return_value=httpx.Response(200, json={"auth_url": "https://example.com/auth"})
+    )
+
+    # Mock webbrowser.open to do nothing (simulates browser opening but no callback)
+    monkeypatch.setattr("webbrowser.open", lambda url: True)
+
+    # Mock OAuthCallbackServer.wait_for_token to return None (timeout)
+    monkeypatch.setattr(
+        "cited_cli.auth.oauth_server.OAuthCallbackServer.wait_for_token",
+        lambda self: None,
+    )
+
+    # CliRunner replaces sys.stdin, so patch the helper used by auth.py
+    monkeypatch.setattr("cited_cli.commands.auth._is_interactive", lambda: True)
+
+    result = runner.invoke(
+        cli_app,
+        ["--env", "prod", "login", "--provider", "google"],
+        input="pasted-jwt-token\n",
+    )
+    assert result.exit_code == 0
+    assert "Logged in" in result.output
+
+    creds = json.loads(creds_file.read_text())
+    assert creds["prod"] == "pasted-jwt-token"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,1381 @@
+"""
+Integration and unit tests for the full cited CLI pipeline.
+
+Assumes the user is already logged in to the dev environment (pre-seeded token).
+
+Pipeline under test:
+  1.  cited business create           → extracts BUSINESS_ID
+  2.  cited audit template create     → extracts TEMPLATE_ID
+  3.  cited audit start <TEMPLATE_ID> → extracts AUDIT_JOB_ID
+  4.  cited job watch  <AUDIT_JOB_ID> → polls until completed
+  5.  cited audit result <AUDIT_JOB_ID>  → displays questions / citations
+  6.  cited business crawl <BUSINESS_ID> → triggers crawl
+  7.  cited business health <BUSINESS_ID> → displays health scores
+  8.  cited recommend start <AUDIT_JOB_ID>   → extracts RECOMMEND_JOB_ID
+  9.  cited job watch  <RECOMMEND_JOB_ID>    → polls until completed
+  10. cited recommend insights <RECOMMEND_JOB_ID> → prints source table
+  11. cited solution start <RECOMMEND_JOB_ID> --type ... --source ... → nudge to web
+
+State threading strategy
+------------------------
+Every command that produces an ID is run with the global --json flag.
+`json.loads(result.output)` extracts the ID and passes it to the next command,
+mirroring the bash pattern of `BUSINESS_ID=$(cited --json business create ...)`.
+
+watch_job is monkeypatched to return an instant "completed" dict — this keeps
+tests fast and avoids Rich's Live renderer interacting with the CliRunner's
+StringIO stdout.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+import respx
+from typer.testing import CliRunner
+
+from cited_cli.app import app
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Pipeline-wide ID constants
+# These UUIDs are used as the canonical IDs throughout all tests in this file.
+# ─────────────────────────────────────────────────────────────────────────────
+BUSINESS_ID       = "b1a2c3d4-e5f6-7890-abcd-ef1234567890"
+TEMPLATE_ID       = "t1a2c3d4-e5f6-7890-abcd-ef1234567891"
+AUDIT_JOB_ID      = "a1a2c3d4-e5f6-7890-abcd-ef1234567892"
+RECOMMEND_JOB_ID  = "r1a2c3d4-e5f6-7890-abcd-ef1234567893"
+SOLUTION_JOB_ID   = "s1a2c3d4-e5f6-7890-abcd-ef1234567894"
+CRAWL_JOB_ID      = "c1a2c3d4-e5f6-7890-abcd-ef1234567895"
+QI_SOURCE_ID      = "qi-abc123def456"       # question_insight source
+HTH_COMPETITOR_DOMAIN = "competitorx.com"  # head_to_head competitor_domain
+
+# Dev API base URL (matches cited_cli/config/constants.py ENVIRONMENTS["dev"])
+DEV_API = "https://dev.youcited.com"
+DEV_WEB = "https://dev.youcited.com"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Canonical mock API responses
+# Each dict mirrors what the real backend would return for that endpoint.
+# ─────────────────────────────────────────────────────────────────────────────
+MOCK_BUSINESS = {
+    "id": BUSINESS_ID,
+    "name": "Acme GEO Corp",
+    "website": "https://acme.example.com",
+    "industry": "SaaS",
+    "description": "Acme makes AI-powered tools for enterprise teams with great GEO presence.",
+    "created_at": "2026-03-17T12:00:00Z",
+    "updated_at": "2026-03-17T12:00:00Z",
+}
+
+MOCK_TEMPLATE = {
+    "id": TEMPLATE_ID,
+    "name": "Q4 GEO Audit",
+    "description": "Checks citation presence across key GEO keywords",
+    "business_id": BUSINESS_ID,
+    "business_name": "Acme GEO Corp",
+    "questions": [
+        {"id": "q1", "question": "Are you cited when people ask about AI tools?"},
+        {"id": "q2", "question": "Does your product appear for enterprise GEO searches?"},
+    ],
+    "created_at": "2026-03-17T12:01:00Z",
+}
+
+MOCK_TEMPLATE_UPDATED = {
+    "id": TEMPLATE_ID,
+    "name": "Q4 GEO Audit Revised",
+    "description": "Updated scope for Q4",
+    "business_id": BUSINESS_ID,
+    "business_name": "Acme GEO Corp",
+    "questions": [
+        {"id": "q1", "question": "Are we cited for AI safety research?"},
+        {"id": "q2", "question": "Do enterprise buyers find us via AI assistants?"},
+        {"id": "q3", "question": "Are we mentioned in responsible AI discussions?"},
+    ],
+    "created_at": "2026-03-17T12:01:00Z",
+    "updated_at": "2026-03-17T14:00:00Z",
+}
+
+MOCK_AUDIT_STARTED = {
+    "job_id": AUDIT_JOB_ID,
+    "status": "pending",
+    "named_audit_id": TEMPLATE_ID,
+    "business_id": BUSINESS_ID,
+    "created_at": "2026-03-17T12:02:00Z",
+}
+
+MOCK_AUDIT_STATUS_COMPLETED = {
+    "job_id": AUDIT_JOB_ID,
+    "status": "completed",
+    "progress": 1.0,
+    "message": "All questions processed",
+}
+
+MOCK_AUDIT_RESULT = {
+    "job_id": AUDIT_JOB_ID,
+    "status": "completed",
+    "business_id": BUSINESS_ID,
+    "questions": [
+        {
+            "question": "Are you cited when people ask about AI tools?",
+            "cited": True,
+            "citation_count": 3,
+            "providers": ["openai", "perplexity"],
+        },
+        {
+            "question": "Does your product appear for enterprise GEO searches?",
+            "cited": False,
+            "citation_count": 0,
+            "providers": [],
+        },
+    ],
+    "overall_citation_rate": 0.5,
+}
+
+MOCK_CRAWL_STARTED = {
+    "message": "Crawl job enqueued",
+    "business_id": BUSINESS_ID,
+    "job_id": CRAWL_JOB_ID,
+    "status": "crawling",
+}
+
+MOCK_HEALTH_SCORES = {
+    "business_id": BUSINESS_ID,
+    "scores": {
+        "citation_score": 72,
+        "visibility_score": 58,
+        "trust_score": 65,
+        "content_freshness": 80,
+    },
+}
+
+MOCK_RECOMMEND_STARTED = {
+    "job_id": RECOMMEND_JOB_ID,
+    "status": "pending",
+    "audit_job_id": AUDIT_JOB_ID,
+    "created_at": "2026-03-17T12:05:00Z",
+}
+
+MOCK_RECOMMEND_STATUS_COMPLETED = {
+    "job_id": RECOMMEND_JOB_ID,
+    "status": "completed",
+    "progress": 1.0,
+    "message": "Recommendations generated",
+}
+
+MOCK_RECOMMEND_RESULT = {
+    "job_id": RECOMMEND_JOB_ID,
+    "status": "completed",
+    # question_insights use question_id + question_text (real API field names)
+    "question_insights": [
+        {
+            "question_id": QI_SOURCE_ID,
+            "question_text": "Are you cited when asked about AI tools?",
+            "risk_level": "high",
+            "coverage_score": 0.33,
+        },
+    ],
+    # head_to_head_comparisons use competitor_domain as the source_id (real API field names)
+    "head_to_head_comparisons": [
+        {
+            "competitor_domain": HTH_COMPETITOR_DOMAIN,
+            "competitor_url": f"https://{HTH_COMPETITOR_DOMAIN}",
+            "business_domain": "acme.example.com",
+            "overall_winner": "competitor",
+        },
+    ],
+    # strengthening_tips use category as source_id, title as description (real API field names)
+    "strengthening_tips": [
+        {
+            "category": "llms_txt",
+            "title": "Add FAQ schema markup to homepage",
+            "priority": "high",
+        },
+    ],
+    "priority_actions": [],
+}
+
+MOCK_SOLUTION_STARTED = {
+    "job_id": SOLUTION_JOB_ID,
+    "status": "pending",
+    "recommendation_job_id": RECOMMEND_JOB_ID,
+    "source_type": "question_insight",
+    "source_id": QI_SOURCE_ID,
+    "created_at": "2026-03-17T12:10:00Z",
+}
+
+# Reusable list of templates (for list endpoint)
+MOCK_TEMPLATE_LIST = [MOCK_TEMPLATE]
+
+# Reusable list of audits (for history endpoint)
+MOCK_AUDIT_LIST = [{"job_id": AUDIT_JOB_ID, "business_name": "Acme GEO Corp", "status": "completed", "created_at": "2026-03-17T12:02:00Z"}]
+
+# Reusable list of recommendations (for history endpoint)
+MOCK_RECOMMEND_LIST = [{"job_id": RECOMMEND_JOB_ID, "status": "completed", "created_at": "2026-03-17T12:05:00Z"}]
+
+# Reusable list of solutions (for history endpoint)
+MOCK_SOLUTION_LIST = [{"job_id": SOLUTION_JOB_ID, "status": "completed", "created_at": "2026-03-17T12:10:00Z"}]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fixtures
+# ─────────────────────────────────────────────────────────────────────────────
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def cli_app():
+    return app
+
+
+def _setup_logged_in(tmp_path, monkeypatch) -> None:
+    """
+    Isolate config to a temp dir and pre-seed a dev auth token.
+    This simulates a user who has already logged in and completed onboarding.
+    """
+    config_dir = tmp_path / ".cited"
+    config_file = config_dir / "config.toml"
+    creds_file  = config_dir / "credentials.json"
+
+    monkeypatch.setattr("cited_cli.config.constants.CONFIG_DIR",      config_dir)
+    monkeypatch.setattr("cited_cli.config.constants.CONFIG_FILE",     config_file)
+    monkeypatch.setattr("cited_cli.config.constants.CREDENTIALS_FILE", creds_file)
+    monkeypatch.setattr("cited_cli.auth.store.CONFIG_DIR",             config_dir)
+    monkeypatch.setattr("cited_cli.auth.store.CREDENTIALS_FILE",       creds_file)
+    # Disable keyring so credentials go to the plain JSON file
+    monkeypatch.setattr("cited_cli.auth.store.TokenStore._has_keyring", lambda self: False)
+
+    config_dir.mkdir(parents=True, exist_ok=True)
+    # Pre-seed a dev token — user is already logged in
+    creds_file.write_text(json.dumps({"dev": "test-jwt-dev-token"}))
+
+
+def _mock_watch_job_completed(job_id: str):
+    """Return a monkeypatch target that resolves watch_job instantly as completed."""
+    def _instant_complete(client, status_path, console, poll_interval=2.0):
+        return {"status": "completed", "job_id": job_id, "progress": 1.0}
+    return _instant_complete
+
+
+def _invoke(runner, cli_app, args: list[str]) -> Any:
+    """Run a CLI command and assert it succeeded, returning the parsed JSON."""
+    result = runner.invoke(cli_app, args)
+    assert result.exit_code == 0, (
+        f"Command failed: cited {' '.join(args)}\n"
+        f"Output: {result.output}"
+    )
+    return result
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Step 1 — Business Creation
+# ─────────────────────────────────────────────────────────────────────────────
+
+@respx.mock
+def test_business_create_returns_id(runner, cli_app, tmp_path, monkeypatch):
+    """business create outputs JSON with an 'id' field in --json mode."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.post(f"{DEV_API}/businesses").mock(
+        return_value=httpx.Response(201, json=MOCK_BUSINESS)
+    )
+
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "--json", "business", "create",
+        "--name", "Acme GEO Corp",
+        "--website", "https://acme.example.com",
+        "--description", "Acme makes AI-powered tools for enterprise teams with great GEO presence.",
+        "--industry", "SaaS",
+    ])
+
+    data = json.loads(result.output)
+    assert data["id"] == BUSINESS_ID
+    assert data["name"] == "Acme GEO Corp"
+    assert data["website"] == "https://acme.example.com"
+
+
+@respx.mock
+def test_business_create_human_output(runner, cli_app, tmp_path, monkeypatch):
+    """business create renders a key-value panel in human mode."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.post(f"{DEV_API}/businesses").mock(
+        return_value=httpx.Response(201, json=MOCK_BUSINESS)
+    )
+
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "business", "create",
+        "--name", "Acme GEO Corp",
+        "--website", "https://acme.example.com",
+        "--description", "Acme makes AI-powered tools for enterprise teams with great GEO presence.",
+    ])
+
+    assert "Acme GEO Corp" in result.output
+    assert "acme.example.com" in result.output
+
+
+@respx.mock
+def test_business_create_api_error(runner, cli_app, tmp_path, monkeypatch):
+    """business create exits non-zero when the API returns 422."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.post(f"{DEV_API}/businesses").mock(
+        return_value=httpx.Response(422, json={"detail": "website is not a valid URL"})
+    )
+
+    result = runner.invoke(cli_app, [
+        "--env", "dev", "business", "create",
+        "--name", "Bad Business",
+        "--website", "not-a-url",
+        "--description", "This should fail because the website is invalid per the backend.",
+    ])
+
+    assert result.exit_code != 0
+
+
+def test_business_create_requires_auth(runner, cli_app, tmp_path, monkeypatch):
+    """business create exits with auth error when no token is present."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    # Override creds file with an empty object (no dev token)
+    creds_file = tmp_path / ".cited" / "credentials.json"
+    creds_file.write_text(json.dumps({}))
+
+    result = runner.invoke(cli_app, [
+        "--env", "dev", "business", "create",
+        "--name", "X",
+        "--website", "https://x.com",
+        "--description", "A valid description that is long enough for the check.",
+    ])
+
+    assert result.exit_code != 0
+    assert "Not logged in" in result.output
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Step 2 — Audit Template CRUD
+# ─────────────────────────────────────────────────────────────────────────────
+
+@respx.mock
+def test_template_create_returns_id(runner, cli_app, tmp_path, monkeypatch):
+    """audit template create returns JSON with an 'id' field usable as next step input."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.post(f"{DEV_API}/named-audits").mock(
+        return_value=httpx.Response(201, json=MOCK_TEMPLATE)
+    )
+
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "--json", "audit", "template", "create",
+        "--name", "Q4 GEO Audit",
+        "--business", BUSINESS_ID,
+        "--description", "Checks citation presence across key GEO keywords",
+        "--question", "Are you cited when people ask about AI tools?",
+        "--question", "Does your product appear for enterprise GEO searches?",
+    ])
+
+    data = json.loads(result.output)
+    assert data["id"] == TEMPLATE_ID
+    assert data["name"] == "Q4 GEO Audit"
+    assert len(data["questions"]) == 2
+
+
+@respx.mock
+def test_template_create_human_output_shows_run_hint(runner, cli_app, tmp_path, monkeypatch):
+    """audit template create (human mode) prints a hint for the next command."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.post(f"{DEV_API}/named-audits").mock(
+        return_value=httpx.Response(201, json=MOCK_TEMPLATE)
+    )
+
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "audit", "template", "create",
+        "--name", "Q4 GEO Audit",
+        "--business", BUSINESS_ID,
+        "--question", "Are you cited when people ask about AI tools?",
+    ])
+
+    assert "cited audit start" in result.output
+    assert TEMPLATE_ID in result.output
+
+
+@respx.mock
+def test_template_list_renders_table(runner, cli_app, tmp_path, monkeypatch):
+    """audit template list renders a table with ID, Name, Business, Questions, Created."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.get(f"{DEV_API}/named-audits").mock(
+        return_value=httpx.Response(200, json=MOCK_TEMPLATE_LIST)
+    )
+
+    result = _invoke(runner, cli_app, ["--env", "dev", "audit", "template", "list"])
+
+    assert "Q4 GEO Audit" in result.output
+    assert "Audit Templates" in result.output
+
+
+@respx.mock
+def test_template_list_filtered_by_business(runner, cli_app, tmp_path, monkeypatch):
+    """audit template list --business sends business_id as query param."""
+    _setup_logged_in(tmp_path, monkeypatch)
+
+    captured_params: dict = {}
+
+    def _capture(request):
+        captured_params.update(dict(request.url.params))
+        return httpx.Response(200, json=MOCK_TEMPLATE_LIST)
+
+    respx.get(f"{DEV_API}/named-audits").mock(side_effect=_capture)
+
+    _invoke(runner, cli_app, [
+        "--env", "dev", "audit", "template", "list",
+        "--business", BUSINESS_ID,
+    ])
+
+    assert captured_params.get("business_id") == BUSINESS_ID
+
+
+@respx.mock
+def test_template_get_shows_questions(runner, cli_app, tmp_path, monkeypatch):
+    """audit template get renders template fields and a numbered question list."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.get(f"{DEV_API}/named-audits/{TEMPLATE_ID}").mock(
+        return_value=httpx.Response(200, json=MOCK_TEMPLATE)
+    )
+
+    result = _invoke(runner, cli_app, ["--env", "dev", "audit", "template", "get", TEMPLATE_ID])
+
+    assert "Q4 GEO Audit" in result.output
+    assert "Are you cited when people ask about AI tools?" in result.output
+    # Questions are numbered
+    assert "1." in result.output
+    assert "2." in result.output
+
+
+@respx.mock
+def test_template_update_replaces_questions(runner, cli_app, tmp_path, monkeypatch):
+    """audit template update --question replaces all questions via PUT."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    captured_body: dict = {}
+
+    def _capture(request: httpx.Request) -> httpx.Response:
+        captured_body.update(json.loads(request.content))
+        return httpx.Response(200, json=MOCK_TEMPLATE_UPDATED)
+
+    respx.put(f"{DEV_API}/named-audits/{TEMPLATE_ID}").mock(side_effect=_capture)
+
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "--json", "audit", "template", "update", TEMPLATE_ID,
+        "--question", "Are we cited for AI safety research?",
+        "--question", "Do enterprise buyers find us via AI assistants?",
+        "--question", "Are we mentioned in responsible AI discussions?",
+    ])
+
+    data = json.loads(result.output)
+    assert data["id"] == TEMPLATE_ID
+    assert len(data["questions"]) == 3
+    # Verify the PUT payload contained all three questions
+    assert len(captured_body["questions"]) == 3
+    assert captured_body["questions"][0]["question"] == "Are we cited for AI safety research?"
+
+
+@respx.mock
+def test_template_update_name_only(runner, cli_app, tmp_path, monkeypatch):
+    """audit template update --name updates only the name, no questions in payload."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    captured_body: dict = {}
+
+    def _capture(request: httpx.Request) -> httpx.Response:
+        captured_body.update(json.loads(request.content))
+        return httpx.Response(200, json=MOCK_TEMPLATE_UPDATED)
+
+    respx.put(f"{DEV_API}/named-audits/{TEMPLATE_ID}").mock(side_effect=_capture)
+
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "--json", "audit", "template", "update", TEMPLATE_ID,
+        "--name", "Q4 GEO Audit Revised",
+    ])
+
+    data = json.loads(result.output)
+    assert data["name"] == "Q4 GEO Audit Revised"
+    assert captured_body["name"] == "Q4 GEO Audit Revised"
+    assert "questions" not in captured_body
+
+
+@respx.mock
+def test_template_update_human_shows_questions(runner, cli_app, tmp_path, monkeypatch):
+    """audit template update human output shows updated questions."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.put(f"{DEV_API}/named-audits/{TEMPLATE_ID}").mock(
+        return_value=httpx.Response(200, json=MOCK_TEMPLATE_UPDATED)
+    )
+
+    result = runner.invoke(cli_app, [
+        "--env", "dev", "audit", "template", "update", TEMPLATE_ID,
+        "--question", "Are we cited for AI safety research?",
+    ])
+
+    assert result.exit_code == 0
+    assert "Template Updated" in result.output
+    assert "Are we cited for AI safety research?" in result.output
+
+
+@respx.mock
+def test_template_update_no_args_exits_with_error(runner, cli_app, tmp_path, monkeypatch):
+    """audit template update with no flags exits with validation error."""
+    _setup_logged_in(tmp_path, monkeypatch)
+
+    result = runner.invoke(cli_app, [
+        "--env", "dev", "audit", "template", "update", TEMPLATE_ID,
+    ])
+
+    assert result.exit_code == 4  # VALIDATION_ERROR
+
+
+@respx.mock
+def test_template_delete_with_flag_skips_prompt(runner, cli_app, tmp_path, monkeypatch):
+    """audit template delete --yes deletes without confirmation prompt."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.delete(f"{DEV_API}/named-audits/{TEMPLATE_ID}").mock(
+        return_value=httpx.Response(204)
+    )
+
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "audit", "template", "delete", TEMPLATE_ID, "--yes",
+    ])
+
+    assert result.exit_code == 0
+
+
+@respx.mock
+def test_template_delete_prompts_without_flag(runner, cli_app, tmp_path, monkeypatch):
+    """audit template delete without --yes prompts for confirmation."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.delete(f"{DEV_API}/named-audits/{TEMPLATE_ID}").mock(
+        return_value=httpx.Response(204)
+    )
+
+    # Answer "n" → Abort
+    result = runner.invoke(
+        cli_app,
+        ["--env", "dev", "audit", "template", "delete", TEMPLATE_ID],
+        input="n\n",
+    )
+    assert result.exit_code != 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Step 3 — Audit Start
+# ─────────────────────────────────────────────────────────────────────────────
+
+@respx.mock
+def test_audit_start_returns_job_id(runner, cli_app, tmp_path, monkeypatch):
+    """audit start returns JSON with a job_id field."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.post(f"{DEV_API}/audit/start").mock(
+        return_value=httpx.Response(202, json=MOCK_AUDIT_STARTED)
+    )
+
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "--json", "audit", "start", TEMPLATE_ID,
+    ])
+
+    data = json.loads(result.output)
+    assert data["job_id"] == AUDIT_JOB_ID
+    assert data["status"] == "pending"
+
+
+@respx.mock
+def test_audit_start_sends_named_audit_id(runner, cli_app, tmp_path, monkeypatch):
+    """audit start sends named_audit_id (not business_id) in the request body."""
+    _setup_logged_in(tmp_path, monkeypatch)
+
+    captured_body: dict = {}
+
+    def _capture(request):
+        captured_body.update(json.loads(request.content))
+        return httpx.Response(202, json=MOCK_AUDIT_STARTED)
+
+    respx.post(f"{DEV_API}/audit/start").mock(side_effect=_capture)
+
+    _invoke(runner, cli_app, [
+        "--env", "dev", "audit", "start", TEMPLATE_ID,
+        "--business", BUSINESS_ID,
+    ])
+
+    assert captured_body.get("named_audit_id") == TEMPLATE_ID
+    assert captured_body.get("business_id") == BUSINESS_ID
+    # Must NOT send old-style business_id-only payload
+    assert "recommendation_id" not in captured_body
+
+
+@respx.mock
+def test_audit_start_with_providers(runner, cli_app, tmp_path, monkeypatch):
+    """audit start --provider flags are collected into a list in the payload."""
+    _setup_logged_in(tmp_path, monkeypatch)
+
+    captured_body: dict = {}
+
+    def _capture(request):
+        captured_body.update(json.loads(request.content))
+        return httpx.Response(202, json=MOCK_AUDIT_STARTED)
+
+    respx.post(f"{DEV_API}/audit/start").mock(side_effect=_capture)
+
+    _invoke(runner, cli_app, [
+        "--env", "dev", "audit", "start", TEMPLATE_ID,
+        "--provider", "openai",
+        "--provider", "perplexity",
+    ])
+
+    assert set(captured_body.get("providers", [])) == {"openai", "perplexity"}
+
+
+@respx.mock
+def test_audit_start_human_output_shows_watch_hint(runner, cli_app, tmp_path, monkeypatch):
+    """audit start (human mode) prints a 'cited job watch' hint."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.post(f"{DEV_API}/audit/start").mock(
+        return_value=httpx.Response(202, json=MOCK_AUDIT_STARTED)
+    )
+
+    result = _invoke(runner, cli_app, ["--env", "dev", "audit", "start", TEMPLATE_ID])
+
+    assert "cited job watch" in result.output
+    assert AUDIT_JOB_ID in result.output
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Step 4 — Job Watch (Audit)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@respx.mock
+def test_job_watch_audit_completes(runner, cli_app, tmp_path, monkeypatch):
+    """job watch polls the audit status endpoint and prints 'completed' on success."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        "cited_cli.commands.job.watch_job",
+        _mock_watch_job_completed(AUDIT_JOB_ID),
+    )
+
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "job", "watch", AUDIT_JOB_ID, "--type", "audit",
+    ])
+
+    assert "completed" in result.output.lower()
+
+
+@respx.mock
+def test_job_watch_auto_detects_audit_type(runner, cli_app, tmp_path, monkeypatch):
+    """job watch without --type probes status endpoints to identify the job type."""
+    _setup_logged_in(tmp_path, monkeypatch)
+
+    # _guess_job_type probes /audit/{id}/status first — return a 200
+    respx.get(f"{DEV_API}/audit/{AUDIT_JOB_ID}/status").mock(
+        return_value=httpx.Response(200, json=MOCK_AUDIT_STATUS_COMPLETED)
+    )
+
+    monkeypatch.setattr(
+        "cited_cli.commands.job.watch_job",
+        _mock_watch_job_completed(AUDIT_JOB_ID),
+    )
+
+    result = _invoke(runner, cli_app, ["--env", "dev", "job", "watch", AUDIT_JOB_ID])
+
+    assert result.exit_code == 0
+
+
+@respx.mock
+def test_job_watch_failed_job_exits_nonzero(runner, cli_app, tmp_path, monkeypatch):
+    """job watch returns a non-zero exit code when the job status is 'failed'."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        "cited_cli.commands.job.watch_job",
+        lambda client, path, console, poll_interval=2.0: {
+            "status": "failed",
+            "job_id": AUDIT_JOB_ID,
+            "error": "Provider timeout",
+        },
+    )
+
+    result = runner.invoke(cli_app, [
+        "--env", "dev", "job", "watch", AUDIT_JOB_ID, "--type", "audit",
+    ])
+
+    assert result.exit_code != 0
+    assert "failed" in result.output.lower() or "Provider timeout" in result.output
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Step 5 — Audit Result
+# ─────────────────────────────────────────────────────────────────────────────
+
+@respx.mock
+def test_audit_result_json_output(runner, cli_app, tmp_path, monkeypatch):
+    """audit result returns JSON with question-level citation data."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.get(f"{DEV_API}/audit/{AUDIT_JOB_ID}/result").mock(
+        return_value=httpx.Response(200, json=MOCK_AUDIT_RESULT)
+    )
+
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "--json", "audit", "result", AUDIT_JOB_ID,
+    ])
+
+    data = json.loads(result.output)
+    assert data["job_id"] == AUDIT_JOB_ID
+    assert len(data["questions"]) == 2
+    assert data["questions"][0]["cited"] is True
+    assert data["questions"][1]["cited"] is False
+    assert data["overall_citation_rate"] == 0.5
+
+
+@respx.mock
+def test_audit_list_renders_table(runner, cli_app, tmp_path, monkeypatch):
+    """audit list renders a table with job ID, business, status, and created columns."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.get(f"{DEV_API}/audit/history").mock(
+        return_value=httpx.Response(200, json=MOCK_AUDIT_LIST)
+    )
+
+    result = _invoke(runner, cli_app, ["--env", "dev", "audit", "list"])
+
+    assert "Audit History" in result.output
+    assert "Acme GEO Corp" in result.output
+    assert "completed" in result.output
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Step 6 — Business Crawl
+# ─────────────────────────────────────────────────────────────────────────────
+
+@respx.mock
+def test_business_crawl_starts_successfully(runner, cli_app, tmp_path, monkeypatch):
+    """business crawl posts to the crawl endpoint and shows 'Crawl Started'."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.post(f"{DEV_API}/businesses/{BUSINESS_ID}/crawl").mock(
+        return_value=httpx.Response(202, json=MOCK_CRAWL_STARTED)
+    )
+
+    result = _invoke(runner, cli_app, ["--env", "dev", "business", "crawl", BUSINESS_ID])
+
+    assert "Crawl" in result.output
+    assert CRAWL_JOB_ID in result.output
+
+
+@respx.mock
+def test_business_crawl_json_output(runner, cli_app, tmp_path, monkeypatch):
+    """business crawl with --json returns the raw crawl response."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.post(f"{DEV_API}/businesses/{BUSINESS_ID}/crawl").mock(
+        return_value=httpx.Response(202, json=MOCK_CRAWL_STARTED)
+    )
+
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "--json", "business", "crawl", BUSINESS_ID,
+    ])
+
+    data = json.loads(result.output)
+    assert data["business_id"] == BUSINESS_ID
+    assert data["job_id"] == CRAWL_JOB_ID
+    assert data["status"] == "crawling"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Step 7 — Business Health (view crawl results)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@respx.mock
+def test_business_health_renders_score_bars(runner, cli_app, tmp_path, monkeypatch):
+    """business health displays score bars after a crawl has completed."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.get(f"{DEV_API}/businesses/{BUSINESS_ID}/health-scores").mock(
+        return_value=httpx.Response(200, json=MOCK_HEALTH_SCORES)
+    )
+
+    result = _invoke(runner, cli_app, ["--env", "dev", "business", "health", BUSINESS_ID])
+
+    assert "Health Scores" in result.output
+    # Score labels are displayed (snake_case -> Title Case)
+    assert "72" in result.output
+    assert "58" in result.output
+
+
+@respx.mock
+def test_business_health_json_output(runner, cli_app, tmp_path, monkeypatch):
+    """business health --json returns structured score data."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.get(f"{DEV_API}/businesses/{BUSINESS_ID}/health-scores").mock(
+        return_value=httpx.Response(200, json=MOCK_HEALTH_SCORES)
+    )
+
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "--json", "business", "health", BUSINESS_ID,
+    ])
+
+    data = json.loads(result.output)
+    scores = data.get("scores", {})
+    assert scores["citation_score"] == 72
+    assert scores["visibility_score"] == 58
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Step 8 — Recommend Start
+# ─────────────────────────────────────────────────────────────────────────────
+
+@respx.mock
+def test_recommend_start_returns_job_id(runner, cli_app, tmp_path, monkeypatch):
+    """recommend start returns JSON with a job_id to feed into job watch."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.post(f"{DEV_API}/recommendations/start").mock(
+        return_value=httpx.Response(202, json=MOCK_RECOMMEND_STARTED)
+    )
+
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "--json", "recommend", "start", AUDIT_JOB_ID,
+    ])
+
+    data = json.loads(result.output)
+    assert data["job_id"] == RECOMMEND_JOB_ID
+    assert data["audit_job_id"] == AUDIT_JOB_ID
+
+
+@respx.mock
+def test_recommend_start_sends_audit_job_id(runner, cli_app, tmp_path, monkeypatch):
+    """recommend start POSTs {audit_job_id: ...} to /recommendations/start."""
+    _setup_logged_in(tmp_path, monkeypatch)
+
+    captured_body: dict = {}
+
+    def _capture(request):
+        captured_body.update(json.loads(request.content))
+        return httpx.Response(202, json=MOCK_RECOMMEND_STARTED)
+
+    respx.post(f"{DEV_API}/recommendations/start").mock(side_effect=_capture)
+
+    _invoke(runner, cli_app, ["--env", "dev", "recommend", "start", AUDIT_JOB_ID])
+
+    assert captured_body.get("audit_job_id") == AUDIT_JOB_ID
+
+
+@respx.mock
+def test_recommend_start_human_output_shows_watch_hint(runner, cli_app, tmp_path, monkeypatch):
+    """recommend start (human mode) prints a 'cited job watch' hint."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.post(f"{DEV_API}/recommendations/start").mock(
+        return_value=httpx.Response(202, json=MOCK_RECOMMEND_STARTED)
+    )
+
+    result = _invoke(runner, cli_app, ["--env", "dev", "recommend", "start", AUDIT_JOB_ID])
+
+    assert "cited job watch" in result.output
+    assert RECOMMEND_JOB_ID in result.output
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Step 9 — Job Watch (Recommendations)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@respx.mock
+def test_job_watch_recommend_completes(runner, cli_app, tmp_path, monkeypatch):
+    """job watch on a recommendations job exits zero and prints completion."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        "cited_cli.commands.job.watch_job",
+        _mock_watch_job_completed(RECOMMEND_JOB_ID),
+    )
+
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "job", "watch", RECOMMEND_JOB_ID,
+        "--type", "recommendations",
+    ])
+
+    assert "completed" in result.output.lower()
+
+
+@respx.mock
+def test_job_watch_auto_detects_recommend_type(runner, cli_app, tmp_path, monkeypatch):
+    """_guess_job_type falls through /audit (404) then succeeds on /recommendations."""
+    _setup_logged_in(tmp_path, monkeypatch)
+
+    # audit probe → 404
+    respx.get(f"{DEV_API}/audit/{RECOMMEND_JOB_ID}/status").mock(
+        return_value=httpx.Response(404, json={"detail": "not found"})
+    )
+    # recommendations probe → 200
+    respx.get(f"{DEV_API}/recommendations/{RECOMMEND_JOB_ID}/status").mock(
+        return_value=httpx.Response(200, json=MOCK_RECOMMEND_STATUS_COMPLETED)
+    )
+
+    monkeypatch.setattr(
+        "cited_cli.commands.job.watch_job",
+        _mock_watch_job_completed(RECOMMEND_JOB_ID),
+    )
+
+    result = _invoke(runner, cli_app, ["--env", "dev", "job", "watch", RECOMMEND_JOB_ID])
+
+    assert result.exit_code == 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Step 10 — Recommend Insights
+# ─────────────────────────────────────────────────────────────────────────────
+
+@respx.mock
+def test_recommend_insights_table_contains_source_ids(runner, cli_app, tmp_path, monkeypatch):
+    """recommend insights renders a table with Type, Source ID, and Description columns."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.get(f"{DEV_API}/recommendations/{RECOMMEND_JOB_ID}/result").mock(
+        return_value=httpx.Response(200, json=MOCK_RECOMMEND_RESULT)
+    )
+
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "recommend", "insights", RECOMMEND_JOB_ID,
+    ])
+
+    assert "Available Insights" in result.output
+    # question_id is the source_id for question_insights
+    assert QI_SOURCE_ID in result.output
+    # competitor_domain is the source_id for head_to_head_comparisons
+    assert HTH_COMPETITOR_DOMAIN in result.output
+    # category is the source_id for strengthening_tips
+    assert "llms_txt" in result.output
+    # Source types appear in the Type column
+    assert "question_insight" in result.output
+    assert "head_to_head" in result.output
+    assert "strengthening_tip" in result.output
+
+
+@respx.mock
+def test_recommend_insights_shows_solution_command_hint(runner, cli_app, tmp_path, monkeypatch):
+    """recommend insights prints a 'cited solution start' hint with the job_id pre-filled."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.get(f"{DEV_API}/recommendations/{RECOMMEND_JOB_ID}/result").mock(
+        return_value=httpx.Response(200, json=MOCK_RECOMMEND_RESULT)
+    )
+
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "recommend", "insights", RECOMMEND_JOB_ID,
+    ])
+
+    assert "cited solution start" in result.output
+    assert RECOMMEND_JOB_ID in result.output
+
+
+@respx.mock
+def test_recommend_insights_json_output(runner, cli_app, tmp_path, monkeypatch):
+    """recommend insights --json returns the raw result (usable for scripting)."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.get(f"{DEV_API}/recommendations/{RECOMMEND_JOB_ID}/result").mock(
+        return_value=httpx.Response(200, json=MOCK_RECOMMEND_RESULT)
+    )
+
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "--json", "recommend", "insights", RECOMMEND_JOB_ID,
+    ])
+
+    data = json.loads(result.output)
+    # Real API uses question_id (not id) for question_insights
+    assert data["question_insights"][0]["question_id"] == QI_SOURCE_ID
+    # Real API uses head_to_head_comparisons (not head_to_head) with competitor_domain as id
+    assert data["head_to_head_comparisons"][0]["competitor_domain"] == HTH_COMPETITOR_DOMAIN
+
+
+@respx.mock
+def test_recommend_insights_field_name_regression(runner, cli_app, tmp_path, monkeypatch):
+    """
+    Regression: the insights command uses real API field names, not assumed ones.
+    - question_insights: question_id (not id), question_text (not question)
+    - head_to_head: head_to_head_comparisons key (not head_to_head), competitor_domain as source_id
+    - strengthening_tips: category as source_id (no uuid id field)
+
+    These field names were verified against the live API on 2026-03-18.
+    """
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.get(f"{DEV_API}/recommendations/{RECOMMEND_JOB_ID}/result").mock(
+        return_value=httpx.Response(200, json=MOCK_RECOMMEND_RESULT)
+    )
+
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "recommend", "insights", RECOMMEND_JOB_ID,
+    ])
+
+    # question_insight row: source_id is question_id value
+    assert QI_SOURCE_ID in result.output
+    # head_to_head row: source_id is competitor_domain value
+    assert HTH_COMPETITOR_DOMAIN in result.output
+    # strengthening_tip row: source_id is category value (not a uuid)
+    assert "llms_txt" in result.output
+    # Descriptions come from question_text and title respectively
+    # (table may wrap long text, so check a prefix that fits on one line)
+    assert "Are you cited when asked about AI" in result.output
+    assert "Add FAQ schema markup to homepage" in result.output
+
+
+@respx.mock
+def test_recommend_list_renders_table(runner, cli_app, tmp_path, monkeypatch):
+    """recommend list renders a table of past recommendation jobs."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.get(f"{DEV_API}/recommendations/audit/{AUDIT_JOB_ID}/history").mock(
+        return_value=httpx.Response(200, json=MOCK_RECOMMEND_LIST)
+    )
+
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "recommend", "list", "--audit", AUDIT_JOB_ID,
+    ])
+
+    assert "Recommendations" in result.output
+    assert "completed" in result.output
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Step 11 — Solution Start
+# ─────────────────────────────────────────────────────────────────────────────
+
+@respx.mock
+def test_solution_start_returns_job_id(runner, cli_app, tmp_path, monkeypatch):
+    """solution start returns JSON with a job_id."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.post(f"{DEV_API}/solutions/request").mock(
+        return_value=httpx.Response(202, json=MOCK_SOLUTION_STARTED)
+    )
+
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "--json", "solution", "start", RECOMMEND_JOB_ID,
+        "--type", "question_insight",
+        "--source", QI_SOURCE_ID,
+    ])
+
+    data = json.loads(result.output)
+    assert data["job_id"] == SOLUTION_JOB_ID
+    assert data["source_type"] == "question_insight"
+    assert data["source_id"] == QI_SOURCE_ID
+
+
+@respx.mock
+def test_solution_start_uses_solution_request_endpoint(runner, cli_app, tmp_path, monkeypatch):
+    """solution start POSTs to /solutions/request (NOT the deprecated /solutions/create)."""
+    _setup_logged_in(tmp_path, monkeypatch)
+
+    captured_body: dict = {}
+    deprecated_called = False
+
+    def _capture_request(request):
+        captured_body.update(json.loads(request.content))
+        return httpx.Response(202, json=MOCK_SOLUTION_STARTED)
+
+    def _deprecated_called_handler(request):
+        nonlocal deprecated_called
+        deprecated_called = True
+        return httpx.Response(410, json={"detail": "This endpoint is deprecated"})
+
+    respx.post(f"{DEV_API}/solutions/request").mock(side_effect=_capture_request)
+    respx.post(f"{DEV_API}/solutions/create").mock(side_effect=_deprecated_called_handler)
+
+    _invoke(runner, cli_app, [
+        "--env", "dev", "solution", "start", RECOMMEND_JOB_ID,
+        "--type", "question_insight",
+        "--source", QI_SOURCE_ID,
+    ])
+
+    # Correct endpoint was called with the right payload
+    assert captured_body.get("recommendation_job_id") == RECOMMEND_JOB_ID
+    assert captured_body.get("source_type") == "question_insight"
+    assert captured_body.get("source_id") == QI_SOURCE_ID
+    # Old payload shape must NOT be used
+    assert "recommendation_id" not in captured_body
+    # Deprecated endpoint must NOT have been called
+    assert deprecated_called is False
+
+
+@respx.mock
+def test_solution_start_shows_web_nudge(runner, cli_app, tmp_path, monkeypatch):
+    """solution start (human mode) prints a web URL so the user can view artifacts."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.post(f"{DEV_API}/solutions/request").mock(
+        return_value=httpx.Response(202, json=MOCK_SOLUTION_STARTED)
+    )
+
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "solution", "start", RECOMMEND_JOB_ID,
+        "--type", "question_insight",
+        "--source", QI_SOURCE_ID,
+    ])
+
+    # Web nudge must include the solution job ID and point to the dev web origin
+    assert SOLUTION_JOB_ID in result.output
+    assert f"{DEV_WEB}/solutions/{SOLUTION_JOB_ID}" in result.output
+
+
+@respx.mock
+def test_solution_start_shows_watch_hint(runner, cli_app, tmp_path, monkeypatch):
+    """solution start (human mode) also prints a 'cited job watch' hint."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.post(f"{DEV_API}/solutions/request").mock(
+        return_value=httpx.Response(202, json=MOCK_SOLUTION_STARTED)
+    )
+
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "solution", "start", RECOMMEND_JOB_ID,
+        "--type", "question_insight",
+        "--source", QI_SOURCE_ID,
+    ])
+
+    assert "cited job watch" in result.output
+
+
+@respx.mock
+def test_solution_start_requires_type_and_source(runner, cli_app, tmp_path, monkeypatch):
+    """solution start exits with a usage error when --type or --source is missing."""
+    _setup_logged_in(tmp_path, monkeypatch)
+
+    result = runner.invoke(cli_app, [
+        "--env", "dev", "solution", "start", RECOMMEND_JOB_ID,
+        # Missing --type and --source
+    ])
+
+    assert result.exit_code != 0
+
+
+@respx.mock
+def test_solution_list_renders_table(runner, cli_app, tmp_path, monkeypatch):
+    """solution list renders a table of past solution jobs."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.get(f"{DEV_API}/solutions/history").mock(
+        return_value=httpx.Response(200, json=MOCK_SOLUTION_LIST)
+    )
+
+    result = _invoke(runner, cli_app, ["--env", "dev", "solution", "list"])
+
+    assert "Solutions" in result.output
+    assert "completed" in result.output
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Full Pipeline Integration Test
+#
+# Chains every step together using Python variables to thread IDs between
+# commands — the equivalent of bash variable capture:
+#   BUSINESS_ID=$(cited --env dev --json business create ...)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@respx.mock
+def test_full_pipeline(runner, cli_app, tmp_path, monkeypatch):
+    """
+    End-to-end pipeline: business create → template create → audit start →
+    job watch → audit result → business crawl → business health →
+    recommend start → job watch → recommend insights → solution start.
+
+    IDs are extracted from --json output at each step and fed into the next,
+    mirroring real-world scripted usage.
+    """
+    _setup_logged_in(tmp_path, monkeypatch)
+
+    # Monkeypatch watch_job to return instantly without any polling
+    def _fast_watch(client, status_path, console, poll_interval=2.0):
+        # Determine job type from the path to return the right job_id
+        if "recommendations" in status_path:
+            return {"status": "completed", "job_id": RECOMMEND_JOB_ID}
+        if "solutions" in status_path:
+            return {"status": "completed", "job_id": SOLUTION_JOB_ID}
+        return {"status": "completed", "job_id": AUDIT_JOB_ID}
+
+    monkeypatch.setattr("cited_cli.commands.job.watch_job", _fast_watch)
+
+    # ── Register all API mocks ────────────────────────────────────────────────
+    respx.post(f"{DEV_API}/businesses").mock(
+        return_value=httpx.Response(201, json=MOCK_BUSINESS)
+    )
+    respx.post(f"{DEV_API}/named-audits").mock(
+        return_value=httpx.Response(201, json=MOCK_TEMPLATE)
+    )
+    respx.put(f"{DEV_API}/named-audits/{TEMPLATE_ID}").mock(
+        return_value=httpx.Response(200, json=MOCK_TEMPLATE_UPDATED)
+    )
+    respx.post(f"{DEV_API}/audit/start").mock(
+        return_value=httpx.Response(202, json=MOCK_AUDIT_STARTED)
+    )
+    respx.get(f"{DEV_API}/audit/{AUDIT_JOB_ID}/status").mock(
+        return_value=httpx.Response(200, json=MOCK_AUDIT_STATUS_COMPLETED)
+    )
+    respx.get(f"{DEV_API}/audit/{AUDIT_JOB_ID}/result").mock(
+        return_value=httpx.Response(200, json=MOCK_AUDIT_RESULT)
+    )
+    respx.post(f"{DEV_API}/businesses/{BUSINESS_ID}/crawl").mock(
+        return_value=httpx.Response(202, json=MOCK_CRAWL_STARTED)
+    )
+    respx.get(f"{DEV_API}/businesses/{BUSINESS_ID}/health-scores").mock(
+        return_value=httpx.Response(200, json=MOCK_HEALTH_SCORES)
+    )
+    respx.post(f"{DEV_API}/recommendations/start").mock(
+        return_value=httpx.Response(202, json=MOCK_RECOMMEND_STARTED)
+    )
+    respx.get(f"{DEV_API}/recommendations/{RECOMMEND_JOB_ID}/status").mock(
+        return_value=httpx.Response(200, json=MOCK_RECOMMEND_STATUS_COMPLETED)
+    )
+    respx.get(f"{DEV_API}/recommendations/{RECOMMEND_JOB_ID}/result").mock(
+        return_value=httpx.Response(200, json=MOCK_RECOMMEND_RESULT)
+    )
+    respx.post(f"{DEV_API}/solutions/request").mock(
+        return_value=httpx.Response(202, json=MOCK_SOLUTION_STARTED)
+    )
+
+    # ── Step 1: Create a business ─────────────────────────────────────────────
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "--json", "business", "create",
+        "--name", "Acme GEO Corp",
+        "--website", "https://acme.example.com",
+        "--description", "Acme makes AI-powered tools for enterprise teams with great GEO presence.",
+        "--industry", "SaaS",
+    ])
+    business = json.loads(result.output)
+    business_id = business["id"]  # ← threading state into next step
+
+    assert business_id == BUSINESS_ID
+
+    # ── Step 2: Create an audit template ─────────────────────────────────────
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "--json", "audit", "template", "create",
+        "--name", "Q4 GEO Audit",
+        "--business", business_id,  # ← uses business_id from step 1
+        "--description", "Checks citation presence across key GEO keywords",
+        "--question", "Are you cited when people ask about AI tools?",
+        "--question", "Does your product appear for enterprise GEO searches?",
+    ])
+    template = json.loads(result.output)
+    template_id = template["id"]  # ← threading state into next step
+
+    assert template_id == TEMPLATE_ID
+    assert template["business_id"] == business_id
+
+    # ── Step 2b: Refine the template questions ──────────────────────────────
+    # Auto-generated questions are rarely perfect — update before running audit
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "--json", "audit", "template", "update",
+        template_id,
+        "--name", "Q4 GEO Audit Revised",
+        "--question", "Are we cited for AI safety research?",
+        "--question", "Do enterprise buyers find us via AI assistants?",
+        "--question", "Are we mentioned in responsible AI discussions?",
+    ])
+    updated = json.loads(result.output)
+    assert updated["id"] == template_id
+    assert len(updated["questions"]) == 3
+    assert updated["name"] == "Q4 GEO Audit Revised"
+
+    # ── Step 3: Start the audit ───────────────────────────────────────────────
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "--json", "audit", "start",
+        template_id,  # ← uses template_id from step 2
+        "--business", business_id,
+    ])
+    audit_started = json.loads(result.output)
+    audit_job_id = audit_started["job_id"]  # ← threading state into next step
+
+    assert audit_job_id == AUDIT_JOB_ID
+    assert audit_started["status"] == "pending"
+
+    # ── Step 4: Watch audit job until completion ──────────────────────────────
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "job", "watch",
+        audit_job_id,  # ← uses audit_job_id from step 3
+        "--type", "audit",
+    ])
+    assert "completed" in result.output.lower()
+
+    # ── Step 5: View audit results in CLI ─────────────────────────────────────
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "--json", "audit", "result",
+        audit_job_id,  # ← same audit_job_id
+    ])
+    audit_result = json.loads(result.output)
+
+    assert audit_result["job_id"] == audit_job_id
+    assert len(audit_result["questions"]) == 2
+    # One question was cited, one was not
+    cited_questions    = [q for q in audit_result["questions"] if q["cited"]]
+    uncited_questions  = [q for q in audit_result["questions"] if not q["cited"]]
+    assert len(cited_questions) == 1
+    assert len(uncited_questions) == 1
+
+    # ── Step 6: Scan/crawl the business ──────────────────────────────────────
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "--json", "business", "crawl",
+        business_id,  # ← uses business_id from step 1
+    ])
+    crawl = json.loads(result.output)
+
+    assert crawl["status"] == "crawling"
+    assert crawl["business_id"] == business_id
+
+    # Extract crawl job_id and watch it
+    crawl_job_id = crawl.get("job_id", "")
+    assert crawl_job_id == CRAWL_JOB_ID
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "job", "watch", crawl_job_id, "--type", "audit",
+    ])
+    assert "completed" in result.output.lower()
+
+    # ── Step 7: View crawl results (health scores) in CLI ────────────────────
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "--json", "business", "health",
+        business_id,  # ← uses business_id from step 1
+    ])
+    health = json.loads(result.output)
+
+    scores = health["scores"]
+    assert scores["citation_score"] == 72
+    assert scores["visibility_score"] == 58
+    # All scores are non-negative integers/floats
+    for score_name, value in scores.items():
+        assert value >= 0, f"{score_name} should be non-negative"
+
+    # ── Step 8: Generate recommendations ─────────────────────────────────────
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "--json", "recommend", "start",
+        audit_job_id,  # ← uses audit_job_id from step 3
+    ])
+    recommend_started = json.loads(result.output)
+    recommend_job_id = recommend_started["job_id"]  # ← threading state into next step
+
+    assert recommend_job_id == RECOMMEND_JOB_ID
+    assert recommend_started["audit_job_id"] == audit_job_id
+
+    # ── Step 9: Watch recommendation job until completion ────────────────────
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "job", "watch",
+        recommend_job_id,  # ← uses recommend_job_id from step 8
+        "--type", "recommendations",
+    ])
+    assert "completed" in result.output.lower()
+
+    # ── Step 10: View insights — discover what to solve ──────────────────────
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "--json", "recommend", "insights",
+        recommend_job_id,  # ← uses recommend_job_id from step 8
+    ])
+    insights = json.loads(result.output)
+
+    # Extract the first question_insight source_id (what the user will pass to solution start)
+    # Real API uses question_id as the source identifier, not id
+    question_insights = insights["question_insights"]
+    assert len(question_insights) > 0
+    source_id = question_insights[0]["question_id"]  # ← threading state into next step
+
+    assert source_id == QI_SOURCE_ID
+
+    # ── Step 11: Start a solution for that insight ────────────────────────────
+    # Run in human mode to verify the web nudge is printed
+    result = _invoke(runner, cli_app, [
+        "--env", "dev", "solution", "start",
+        recommend_job_id,          # ← uses recommend_job_id from step 8
+        "--type", "question_insight",
+        "--source", source_id,     # ← uses source_id from step 10
+    ])
+
+    # Verify the job started
+    assert "Solution Started" in result.output
+
+    # Verify the web nudge is shown (rich documents → web only)
+    assert SOLUTION_JOB_ID in result.output
+    assert f"{DEV_WEB}/solutions/{SOLUTION_JOB_ID}" in result.output
+
+    # Verify the watch hint is shown
+    assert "cited job watch" in result.output


### PR DESCRIPTION
…mand improvements

- Add browser-based OAuth login with localhost callback server and paste fallback
- Add `cited register` with email verification flow (cli-register + cli-verify-email)
- Add `cited login/logout/register` as top-level commands (auth subgroup kept for compat)
- Add audit template CRUD commands (cited audit template list|get|create|update|delete)
- Add named_audit_id support for audit start
- Improve recommend and solution commands with updated API field mappings
- Add FRONTEND_URLS and DEFAULT_ENV constants
- Update tests, docs, README, and test runbook