### PR TITLE
feat: remote MCP server with stateless OAuth

### DIFF
--- a/cited-plugins/.mcp.json
+++ b/cited-plugins/.mcp.json
@@ -1,11 +1,8 @@
 {
   "mcpServers": {
     "cited": {
-      "command": "uvx",
-      "args": ["cited-mcp"],
-      "env": {
-        "CITED_ENV": "prod"
-      }
+      "type": "http",
+      "url": "https://mcpdev.youcited.com"
     }
   }
 }

--- a/cited-plugins/CLAUDE_DESKTOP_SETUP.md
+++ b/cited-plugins/CLAUDE_DESKTOP_SETUP.md
@@ -4,75 +4,38 @@ This guide walks you through connecting Claude Desktop to the Cited GEO platform
 
 ## What You Need
 
-- **Claude Desktop** app installed on your Mac
+- **Claude Desktop** app installed
 - **A Cited account** at [youcited.com](https://youcited.com)
-- **uv** (a Python tool runner) — we'll install this in step 1
+- **Node.js** installed (download from [nodejs.org](https://nodejs.org))
 
-## Step 1: Install uv
-
-Open the **Terminal** app (search for "Terminal" in Spotlight, or find it in Applications > Utilities).
-
-Copy and paste this command, then press Enter:
-
-```
-curl -LsSf https://astral.sh/uv/install.sh | sh
-```
-
-Close and reopen Terminal after it finishes.
-
-## Step 2: Get Your Auth Token
-
-You need a session token from the Cited web app. The easiest way is to use the Cited CLI:
-
-```
-uvx cited-cli login --env dev
-```
-
-This opens your browser. Log in with your Cited account (Google, Microsoft, GitHub, or email). Once you see "Authentication successful", you can close the browser tab.
-
-## Step 3: Configure Claude Desktop
+## Step 1: Configure Claude Desktop
 
 1. Open Claude Desktop
-2. Click the **Claude** menu in the top-left corner of your screen
+2. Click the **Claude** menu (top-left on Mac, top bar on Windows)
 3. Click **Settings**
 4. Click **Developer** in the left sidebar
 5. Click **Edit Config**
 
-This opens a file called `claude_desktop_config.json`. Replace its entire contents with:
+This opens `claude_desktop_config.json`. Add the `mcpServers` section:
 
 ```json
 {
   "mcpServers": {
     "cited": {
-      "command": "PATH_TO_UVX",
-      "args": ["cited-mcp"],
-      "env": {
-        "CITED_ENV": "dev"
-      }
+      "command": "npx",
+      "args": ["mcp-remote", "https://mcp.youcited.com"]
     }
   }
 }
 ```
 
-**Important:** Replace `PATH_TO_UVX` with the actual path to uvx on your machine. To find it, open Terminal and run:
+Save the file and close the text editor.
 
-```
-which uvx
-```
+## Step 2: Restart Claude Desktop
 
-It's usually one of these:
-- `/Users/YOUR_USERNAME/.local/bin/uvx` (most common)
-- `/opt/homebrew/bin/uvx` (if installed via Homebrew)
+Quit Claude Desktop completely (Cmd+Q on Mac, or close fully on Windows), then reopen it.
 
-Save the file (Command + S) and close the text editor.
-
-## Step 4: Restart Claude Desktop
-
-Quit Claude Desktop completely (Command + Q), then reopen it.
-
-You may see a macOS popup asking to allow Python to access your keychain — click **Always Allow** and enter your Mac password. This lets Claude read your Cited login token.
-
-## Step 5: Try It Out
+## Step 3: Try It Out
 
 Start a new conversation in Claude Desktop and try any of these:
 
@@ -80,19 +43,18 @@ Start a new conversation in Claude Desktop and try any of these:
 - **"Run a GEO audit on [business name]"** — audits your AI search presence
 - **"Check my Cited account status"** — verifies you're connected
 
+On first use, your browser will open to log in to your Cited account. After logging in, you'll be redirected back automatically. This only happens once.
+
 ## Troubleshooting
 
-**Claude says "Not authenticated":**
-- Open Terminal and run `uvx cited-cli login --env dev` again
-- Restart Claude Desktop
-
-**Claude doesn't show Cited tools:**
+**Browser login popup doesn't appear:**
+- Make sure Node.js is installed: open a terminal and type `node --version`
 - Make sure you saved the config file correctly
-- Make sure you fully quit and reopened Claude Desktop (not just closed the window)
-- Check that uv is installed: open Terminal and type `uvx --version`
+- Restart Claude Desktop fully (not just close the window)
 
-**Keychain popup keeps appearing:**
-- Click "Always Allow" instead of just "Allow" so it doesn't ask again
+**"npx not found" error:**
+- Install Node.js from [nodejs.org](https://nodejs.org) (LTS version recommended)
+- Restart Claude Desktop after installing Node.js
 
 ## What Can Claude Do With Cited?
 

--- a/packages/core/src/cited_core/api/endpoints.py
+++ b/packages/core/src/cited_core/api/endpoints.py
@@ -6,6 +6,7 @@ CLI_LOGIN = "/auth/cli-login"
 CLI_REGISTER = "/auth/cli-register"
 CLI_VERIFY_EMAIL = "/auth/cli-verify-email"
 CLI_OAUTH_START = "/auth/cli-oauth-start"
+AUTHORIZE_APP = "/auth/authorize-app"
 LOGOUT = "/auth/logout"
 ME = "/auth/me"
 

--- a/packages/core/src/cited_core/config/constants.py
+++ b/packages/core/src/cited_core/config/constants.py
@@ -14,6 +14,12 @@ FRONTEND_URLS: dict[str, str] = {
     "local": "http://localhost:3000",
 }
 
+MCP_URLS: dict[str, str] = {
+    "prod": "https://mcp.youcited.com",
+    "dev": "https://mcpdev.youcited.com",
+    "local": "http://localhost:8080",
+}
+
 DEFAULT_ENV = "prod"
 CONFIG_DIR = Path.home() / ".cited"
 CONFIG_FILE = CONFIG_DIR / "config.toml"

--- a/packages/mcp/Dockerfile
+++ b/packages/mcp/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install core first (dependency), then mcp
+COPY packages/core/ /app/packages/core/
+COPY packages/mcp/ /app/packages/mcp/
+
+RUN pip install --no-cache-dir /app/packages/core /app/packages/mcp
+
+ENV PORT=8080
+EXPOSE 8080
+
+CMD ["cited-mcp-remote"]

--- a/packages/mcp/pyproject.toml
+++ b/packages/mcp/pyproject.toml
@@ -12,10 +12,12 @@ authors = [{ name = "Cited", email = "support@youcited.com" }]
 dependencies = [
     "cited-core>=0.3.2",
     "mcp>=1.26.0",
+    "PyJWT>=2.8.0",
 ]
 
 [project.scripts]
 cited-mcp = "cited_mcp:run_server"
+cited-mcp-remote = "cited_mcp.remote:run_remote_server"
 
 [project.optional-dependencies]
 dev = [

--- a/packages/mcp/src/cited_mcp/auth_provider.py
+++ b/packages/mcp/src/cited_mcp/auth_provider.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import secrets
+import time
+from urllib.parse import urlencode
+
+import jwt
+from mcp.server.auth.provider import (
+    AccessToken,
+    AuthorizationCode,
+    AuthorizationParams,
+    OAuthAuthorizationServerProvider,
+    RefreshToken,
+)
+from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+from pydantic import AnyUrl
+
+
+class CitedAuthCode(AuthorizationCode):
+    """Extended authorization code that carries the user's backend JWT."""
+
+    user_jwt: str
+
+
+class CitedAccessToken(AccessToken):
+    """Extended access token that carries the user's backend JWT."""
+
+    user_jwt: str
+
+
+class CitedRefreshToken(RefreshToken):
+    """Extended refresh token that carries the user's backend JWT."""
+
+    user_jwt: str
+
+
+class CitedOAuthProvider(
+    OAuthAuthorizationServerProvider[CitedAuthCode, CitedRefreshToken, CitedAccessToken],
+):
+    """OAuth provider that delegates user authentication to the Cited backend.
+
+    The MCP server acts as both the OAuth authorization server (for Claude Desktop)
+    and as a relay to the Cited backend API. The flow:
+
+    1. Claude Desktop -> MCP /authorize -> redirect to backend /auth/authorize-app
+    2. Backend authenticates user -> redirects to MCP /oauth/callback with JWT
+    3. MCP /oauth/callback -> generates auth code -> redirects to Claude Desktop
+    4. Claude Desktop -> MCP /token -> exchanges code for access/refresh tokens
+    5. Claude Desktop -> MCP /mcp with Bearer token -> MCP uses stored JWT for API calls
+    """
+
+    def __init__(self, backend_url: str, mcp_url: str, jwt_secret: str) -> None:
+        self.backend_url = backend_url
+        self.mcp_url = mcp_url
+        self.jwt_secret = jwt_secret
+        self._clients: dict[str, OAuthClientInformationFull] = {}
+        self._auth_codes: dict[str, CitedAuthCode] = {}
+        self._access_tokens: dict[str, CitedAccessToken] = {}
+        self._refresh_tokens: dict[str, CitedRefreshToken] = {}
+
+    # -- Client registration (RFC 7591) --
+
+    async def get_client(self, client_id: str) -> OAuthClientInformationFull | None:
+        return self._clients.get(client_id)
+
+    async def register_client(self, client_info: OAuthClientInformationFull) -> None:
+        if client_info.client_id is None:
+            client_info.client_id = secrets.token_urlsafe(24)
+        # Only generate a secret if the client expects one (not "none" auth method)
+        if client_info.token_endpoint_auth_method != "none" and client_info.client_secret is None:
+            client_info.client_secret = secrets.token_urlsafe(48)
+        client_info.client_id_issued_at = int(time.time())
+        self._clients[client_info.client_id] = client_info
+
+    # -- Authorization --
+
+    async def authorize(
+        self,
+        client: OAuthClientInformationFull,
+        params: AuthorizationParams,
+    ) -> str:
+        """Redirect the user to the Cited backend for authentication.
+
+        We encode the original OAuth params into a signed state JWT so the
+        /oauth/callback handler can reconstruct the authorization code response.
+        """
+        state_payload = {
+            "client_id": client.client_id,
+            "code_challenge": params.code_challenge,
+            "redirect_uri": str(params.redirect_uri),
+            "redirect_uri_provided_explicitly": params.redirect_uri_provided_explicitly,
+            "scopes": params.scopes or [],
+            "original_state": params.state,
+            "exp": int(time.time()) + 600,  # 10 minute expiry
+        }
+        if params.resource:
+            state_payload["resource"] = params.resource
+        signed_state = jwt.encode(state_payload, self.jwt_secret, algorithm="HS256")
+
+        callback_url = f"{self.mcp_url}/oauth/callback"
+        query = urlencode({
+            "callback": callback_url,
+            "state": signed_state,
+            "app_name": "Cited MCP",
+        })
+        return f"{self.backend_url}/auth/authorize-app?{query}"
+
+    # -- Authorization code handling --
+
+    async def load_authorization_code(
+        self,
+        client: OAuthClientInformationFull,
+        authorization_code: str,
+    ) -> CitedAuthCode | None:
+        code = self._auth_codes.get(authorization_code)
+        if code and code.client_id != client.client_id:
+            return None
+        return code
+
+    async def exchange_authorization_code(
+        self,
+        client: OAuthClientInformationFull,
+        authorization_code: CitedAuthCode,
+    ) -> OAuthToken:
+        # Remove the auth code (single use)
+        self._auth_codes.pop(authorization_code.code, None)
+
+        user_jwt = authorization_code.user_jwt
+        scopes = authorization_code.scopes
+
+        access_token_str = secrets.token_urlsafe(32)
+        refresh_token_str = secrets.token_urlsafe(32)
+        now = int(time.time())
+
+        self._access_tokens[access_token_str] = CitedAccessToken(
+            token=access_token_str,
+            client_id=client.client_id or "",
+            scopes=scopes,
+            expires_at=now + 3600,
+            user_jwt=user_jwt,
+            resource=authorization_code.resource,
+        )
+
+        self._refresh_tokens[refresh_token_str] = CitedRefreshToken(
+            token=refresh_token_str,
+            client_id=client.client_id or "",
+            scopes=scopes,
+            expires_at=now + 86400 * 30,  # 30 days
+            user_jwt=user_jwt,
+        )
+
+        return OAuthToken(
+            access_token=access_token_str,
+            refresh_token=refresh_token_str,
+            expires_in=3600,
+        )
+
+    # -- Refresh token handling --
+
+    async def load_refresh_token(
+        self,
+        client: OAuthClientInformationFull,
+        refresh_token: str,
+    ) -> CitedRefreshToken | None:
+        rt = self._refresh_tokens.get(refresh_token)
+        if rt and rt.client_id != client.client_id:
+            return None
+        if rt and rt.expires_at and rt.expires_at < time.time():
+            self._refresh_tokens.pop(refresh_token, None)
+            return None
+        return rt
+
+    async def exchange_refresh_token(
+        self,
+        client: OAuthClientInformationFull,
+        refresh_token: CitedRefreshToken,
+        scopes: list[str],
+    ) -> OAuthToken:
+        # Rotate both tokens
+        self._refresh_tokens.pop(refresh_token.token, None)
+        # Revoke old access tokens for this client
+        old_access_keys = [
+            k for k, v in self._access_tokens.items()
+            if v.client_id == client.client_id
+        ]
+        for k in old_access_keys:
+            del self._access_tokens[k]
+
+        user_jwt = refresh_token.user_jwt
+        effective_scopes = scopes if scopes else refresh_token.scopes
+
+        new_access = secrets.token_urlsafe(32)
+        new_refresh = secrets.token_urlsafe(32)
+        now = int(time.time())
+
+        self._access_tokens[new_access] = CitedAccessToken(
+            token=new_access,
+            client_id=client.client_id or "",
+            scopes=effective_scopes,
+            expires_at=now + 3600,
+            user_jwt=user_jwt,
+        )
+
+        self._refresh_tokens[new_refresh] = CitedRefreshToken(
+            token=new_refresh,
+            client_id=client.client_id or "",
+            scopes=effective_scopes,
+            expires_at=now + 86400 * 30,
+            user_jwt=user_jwt,
+        )
+
+        return OAuthToken(
+            access_token=new_access,
+            refresh_token=new_refresh,
+            expires_in=3600,
+        )
+
+    # -- Access token verification --
+
+    async def load_access_token(self, token: str) -> CitedAccessToken | None:
+        at = self._access_tokens.get(token)
+        if at and at.expires_at and at.expires_at < time.time():
+            self._access_tokens.pop(token, None)
+            return None
+        return at
+
+    # -- Revocation --
+
+    async def revoke_token(
+        self,
+        token: CitedAccessToken | CitedRefreshToken,
+    ) -> None:
+        if isinstance(token, CitedAccessToken):
+            self._access_tokens.pop(token.token, None)
+            # Also revoke refresh tokens for same client
+            to_remove = [
+                k for k, v in self._refresh_tokens.items()
+                if v.client_id == token.client_id
+            ]
+            for k in to_remove:
+                del self._refresh_tokens[k]
+        elif isinstance(token, CitedRefreshToken):
+            self._refresh_tokens.pop(token.token, None)
+            # Also revoke access tokens for same client
+            to_remove = [
+                k for k, v in self._access_tokens.items()
+                if v.client_id == token.client_id
+            ]
+            for k in to_remove:
+                del self._access_tokens[k]
+
+    # -- Helper: store auth code from callback --
+
+    def store_auth_code(
+        self,
+        code: str,
+        user_jwt: str,
+        client_id: str,
+        code_challenge: str,
+        redirect_uri: str,
+        redirect_uri_provided_explicitly: bool,
+        scopes: list[str],
+        resource: str | None = None,
+    ) -> None:
+        """Store an authorization code generated by the /oauth/callback handler."""
+        self._auth_codes[code] = CitedAuthCode(
+            code=code,
+            client_id=client_id,
+            code_challenge=code_challenge,
+            redirect_uri=AnyUrl(redirect_uri),
+            redirect_uri_provided_explicitly=redirect_uri_provided_explicitly,
+            scopes=scopes,
+            expires_at=time.time() + 300,  # 5 minute expiry
+            user_jwt=user_jwt,
+            resource=resource,
+        )

--- a/packages/mcp/src/cited_mcp/auth_provider.py
+++ b/packages/mcp/src/cited_mcp/auth_provider.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import secrets
 import time
+from typing import Any
 from urllib.parse import urlencode
 
 import jwt as pyjwt
@@ -72,10 +73,10 @@ class CitedOAuthProvider(
 
     # -- Stateless token helpers --
 
-    def _encode_token(self, payload: dict) -> str:
+    def _encode_token(self, payload: dict[str, Any]) -> str:
         return pyjwt.encode(payload, self.jwt_secret, algorithm="HS256")
 
-    def _decode_token(self, token: str) -> dict | None:
+    def _decode_token(self, token: str) -> dict[str, Any] | None:
         try:
             return pyjwt.decode(token, self.jwt_secret, algorithms=["HS256"])
         except pyjwt.ExpiredSignatureError:

--- a/packages/mcp/src/cited_mcp/auth_provider.py
+++ b/packages/mcp/src/cited_mcp/auth_provider.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import logging
 import secrets
 import time
 from urllib.parse import urlencode
 
-import jwt
+import jwt as pyjwt
 from mcp.server.auth.provider import (
     AccessToken,
     AuthorizationCode,
@@ -14,6 +15,21 @@ from mcp.server.auth.provider import (
 )
 from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 from pydantic import AnyUrl
+
+logger = logging.getLogger(__name__)
+
+
+class _PermissiveLocalhostClient(OAuthClientInformationFull):
+    """Client that accepts any localhost redirect_uri (dynamic ports)."""
+
+    def validate_redirect_uri(self, redirect_uri: AnyUrl | None) -> AnyUrl:
+        if redirect_uri is not None and str(redirect_uri).startswith("http://localhost"):
+            return redirect_uri
+        return super().validate_redirect_uri(redirect_uri)
+
+# Token lifetimes
+ACCESS_TOKEN_TTL = 3600  # 1 hour
+REFRESH_TOKEN_TTL = 86400 * 7  # 7 days (matches backend JWT TTL)
 
 
 class CitedAuthCode(AuthorizationCode):
@@ -39,14 +55,12 @@ class CitedOAuthProvider(
 ):
     """OAuth provider that delegates user authentication to the Cited backend.
 
-    The MCP server acts as both the OAuth authorization server (for Claude Desktop)
-    and as a relay to the Cited backend API. The flow:
+    Access and refresh tokens are **stateless signed JWTs**, so they survive
+    server restarts, deploys, and Fargate Spot reclaims without triggering
+    re-authentication in Claude Desktop.
 
-    1. Claude Desktop -> MCP /authorize -> redirect to backend /auth/authorize-app
-    2. Backend authenticates user -> redirects to MCP /oauth/callback with JWT
-    3. MCP /oauth/callback -> generates auth code -> redirects to Claude Desktop
-    4. Claude Desktop -> MCP /token -> exchanges code for access/refresh tokens
-    5. Claude Desktop -> MCP /mcp with Bearer token -> MCP uses stored JWT for API calls
+    Auth codes remain in-memory (short-lived, single-use, exchanged in seconds).
+    Client registrations are also in-memory — Claude Desktop re-registers each session.
     """
 
     def __init__(self, backend_url: str, mcp_url: str, jwt_secret: str) -> None:
@@ -55,21 +69,114 @@ class CitedOAuthProvider(
         self.jwt_secret = jwt_secret
         self._clients: dict[str, OAuthClientInformationFull] = {}
         self._auth_codes: dict[str, CitedAuthCode] = {}
-        self._access_tokens: dict[str, CitedAccessToken] = {}
-        self._refresh_tokens: dict[str, CitedRefreshToken] = {}
+
+    # -- Stateless token helpers --
+
+    def _encode_token(self, payload: dict) -> str:
+        return pyjwt.encode(payload, self.jwt_secret, algorithm="HS256")
+
+    def _decode_token(self, token: str) -> dict | None:
+        try:
+            return pyjwt.decode(token, self.jwt_secret, algorithms=["HS256"])
+        except pyjwt.ExpiredSignatureError:
+            return None
+        except pyjwt.InvalidTokenError:
+            return None
+
+    def _issue_tokens(
+        self,
+        user_jwt: str,
+        client_id: str,
+        scopes: list[str],
+        resource: str | None = None,
+    ) -> OAuthToken:
+        now = int(time.time())
+
+        access_payload = {
+            "typ": "access",
+            "sub": client_id,
+            "scopes": scopes,
+            "user_jwt": user_jwt,
+            "exp": now + ACCESS_TOKEN_TTL,
+            "iat": now,
+        }
+        if resource:
+            access_payload["resource"] = resource
+
+        refresh_payload = {
+            "typ": "refresh",
+            "sub": client_id,
+            "scopes": scopes,
+            "user_jwt": user_jwt,
+            "exp": now + REFRESH_TOKEN_TTL,
+            "iat": now,
+        }
+
+        return OAuthToken(
+            access_token=self._encode_token(access_payload),
+            refresh_token=self._encode_token(refresh_payload),
+            expires_in=ACCESS_TOKEN_TTL,
+        )
 
     # -- Client registration (RFC 7591) --
+    # Client info is stored in-memory AND encoded into a signed client_id JWT.
+    # On get_client, if the in-memory lookup misses (post-restart), we decode
+    # the client_id JWT to reconstruct the registration — making it survive restarts.
 
     async def get_client(self, client_id: str) -> OAuthClientInformationFull | None:
-        return self._clients.get(client_id)
+        # Try in-memory first
+        client = self._clients.get(client_id)
+        if client:
+            return client
+
+        # Try to reconstruct from signed client_id JWT (post-restart recovery)
+        payload = self._decode_token(client_id)
+        if payload and payload.get("typ") == "client":
+            client_info = OAuthClientInformationFull(
+                client_id=client_id,
+                client_secret=payload.get("client_secret"),
+                client_id_issued_at=payload.get("iat", int(time.time())),
+                redirect_uris=[AnyUrl(u) for u in payload.get("redirect_uris", [])],
+                scope=payload.get("scope"),
+                token_endpoint_auth_method=payload.get("token_endpoint_auth_method", "none"),
+            )
+            self._clients[client_id] = client_info
+            return client_info
+
+        # Accept unknown client IDs (e.g. old UUID-format registrations lost on restart).
+        # Security relies on PKCE, not client identity — this avoids forcing re-registration
+        # on every deploy. We use http://localhost as a permissive redirect_uri since Claude
+        # Desktop uses dynamic localhost ports for OAuth callbacks.
+        logger.info("Auto-accepting unknown client_id: %s", client_id[:12])
+        client_info = _PermissiveLocalhostClient(
+            client_id=client_id,
+            client_id_issued_at=int(time.time()),
+            redirect_uris=[AnyUrl("http://localhost")],
+            scope="cited",
+            token_endpoint_auth_method="none",
+        )
+        self._clients[client_id] = client_info
+        return client_info
 
     async def register_client(self, client_info: OAuthClientInformationFull) -> None:
-        if client_info.client_id is None:
-            client_info.client_id = secrets.token_urlsafe(24)
-        # Only generate a secret if the client expects one (not "none" auth method)
+        # Generate a client_secret if needed
         if client_info.token_endpoint_auth_method != "none" and client_info.client_secret is None:
             client_info.client_secret = secrets.token_urlsafe(48)
-        client_info.client_id_issued_at = int(time.time())
+
+        now = int(time.time())
+        # Encode client registration into a signed JWT as the client_id
+        client_payload = {
+            "typ": "client",
+            "redirect_uris": [str(u) for u in (client_info.redirect_uris or [])],
+            "token_endpoint_auth_method": client_info.token_endpoint_auth_method or "none",
+            "scope": client_info.scope,
+            "iat": now,
+        }
+        if client_info.client_secret:
+            client_payload["client_secret"] = client_info.client_secret
+
+        client_info.client_id = self._encode_token(client_payload)
+        client_info.client_id_issued_at = now
         self._clients[client_info.client_id] = client_info
 
     # -- Authorization --
@@ -79,11 +186,7 @@ class CitedOAuthProvider(
         client: OAuthClientInformationFull,
         params: AuthorizationParams,
     ) -> str:
-        """Redirect the user to the Cited backend for authentication.
-
-        We encode the original OAuth params into a signed state JWT so the
-        /oauth/callback handler can reconstruct the authorization code response.
-        """
+        """Redirect the user to the Cited backend for authentication."""
         state_payload = {
             "client_id": client.client_id,
             "code_challenge": params.code_challenge,
@@ -91,11 +194,11 @@ class CitedOAuthProvider(
             "redirect_uri_provided_explicitly": params.redirect_uri_provided_explicitly,
             "scopes": params.scopes or [],
             "original_state": params.state,
-            "exp": int(time.time()) + 600,  # 10 minute expiry
+            "exp": int(time.time()) + 600,
         }
         if params.resource:
             state_payload["resource"] = params.resource
-        signed_state = jwt.encode(state_payload, self.jwt_secret, algorithm="HS256")
+        signed_state = pyjwt.encode(state_payload, self.jwt_secret, algorithm="HS256")
 
         callback_url = f"{self.mcp_url}/oauth/callback"
         query = urlencode({
@@ -105,7 +208,7 @@ class CitedOAuthProvider(
         })
         return f"{self.backend_url}/auth/authorize-app?{query}"
 
-    # -- Authorization code handling --
+    # -- Authorization code handling (in-memory, short-lived) --
 
     async def load_authorization_code(
         self,
@@ -122,53 +225,33 @@ class CitedOAuthProvider(
         client: OAuthClientInformationFull,
         authorization_code: CitedAuthCode,
     ) -> OAuthToken:
-        # Remove the auth code (single use)
         self._auth_codes.pop(authorization_code.code, None)
-
-        user_jwt = authorization_code.user_jwt
-        scopes = authorization_code.scopes
-
-        access_token_str = secrets.token_urlsafe(32)
-        refresh_token_str = secrets.token_urlsafe(32)
-        now = int(time.time())
-
-        self._access_tokens[access_token_str] = CitedAccessToken(
-            token=access_token_str,
+        return self._issue_tokens(
+            user_jwt=authorization_code.user_jwt,
             client_id=client.client_id or "",
-            scopes=scopes,
-            expires_at=now + 3600,
-            user_jwt=user_jwt,
+            scopes=authorization_code.scopes,
             resource=authorization_code.resource,
         )
 
-        self._refresh_tokens[refresh_token_str] = CitedRefreshToken(
-            token=refresh_token_str,
-            client_id=client.client_id or "",
-            scopes=scopes,
-            expires_at=now + 86400 * 30,  # 30 days
-            user_jwt=user_jwt,
-        )
-
-        return OAuthToken(
-            access_token=access_token_str,
-            refresh_token=refresh_token_str,
-            expires_in=3600,
-        )
-
-    # -- Refresh token handling --
+    # -- Refresh token handling (stateless JWT) --
 
     async def load_refresh_token(
         self,
         client: OAuthClientInformationFull,
         refresh_token: str,
     ) -> CitedRefreshToken | None:
-        rt = self._refresh_tokens.get(refresh_token)
-        if rt and rt.client_id != client.client_id:
+        payload = self._decode_token(refresh_token)
+        if not payload or payload.get("typ") != "refresh":
             return None
-        if rt and rt.expires_at and rt.expires_at < time.time():
-            self._refresh_tokens.pop(refresh_token, None)
+        if payload.get("sub") != client.client_id:
             return None
-        return rt
+        return CitedRefreshToken(
+            token=refresh_token,
+            client_id=payload["sub"],
+            scopes=payload.get("scopes", []),
+            expires_at=payload.get("exp"),
+            user_jwt=payload["user_jwt"],
+        )
 
     async def exchange_refresh_token(
         self,
@@ -176,78 +259,38 @@ class CitedOAuthProvider(
         refresh_token: CitedRefreshToken,
         scopes: list[str],
     ) -> OAuthToken:
-        # Rotate both tokens
-        self._refresh_tokens.pop(refresh_token.token, None)
-        # Revoke old access tokens for this client
-        old_access_keys = [
-            k for k, v in self._access_tokens.items()
-            if v.client_id == client.client_id
-        ]
-        for k in old_access_keys:
-            del self._access_tokens[k]
-
-        user_jwt = refresh_token.user_jwt
         effective_scopes = scopes if scopes else refresh_token.scopes
-
-        new_access = secrets.token_urlsafe(32)
-        new_refresh = secrets.token_urlsafe(32)
-        now = int(time.time())
-
-        self._access_tokens[new_access] = CitedAccessToken(
-            token=new_access,
+        return self._issue_tokens(
+            user_jwt=refresh_token.user_jwt,
             client_id=client.client_id or "",
             scopes=effective_scopes,
-            expires_at=now + 3600,
-            user_jwt=user_jwt,
         )
 
-        self._refresh_tokens[new_refresh] = CitedRefreshToken(
-            token=new_refresh,
-            client_id=client.client_id or "",
-            scopes=effective_scopes,
-            expires_at=now + 86400 * 30,
-            user_jwt=user_jwt,
-        )
-
-        return OAuthToken(
-            access_token=new_access,
-            refresh_token=new_refresh,
-            expires_in=3600,
-        )
-
-    # -- Access token verification --
+    # -- Access token verification (stateless JWT) --
 
     async def load_access_token(self, token: str) -> CitedAccessToken | None:
-        at = self._access_tokens.get(token)
-        if at and at.expires_at and at.expires_at < time.time():
-            self._access_tokens.pop(token, None)
+        payload = self._decode_token(token)
+        if not payload or payload.get("typ") != "access":
             return None
-        return at
+        return CitedAccessToken(
+            token=token,
+            client_id=payload["sub"],
+            scopes=payload.get("scopes", []),
+            expires_at=payload.get("exp"),
+            user_jwt=payload["user_jwt"],
+            resource=payload.get("resource"),
+        )
 
-    # -- Revocation --
+    # -- Revocation (best-effort, no-op for stateless tokens) --
 
     async def revoke_token(
         self,
         token: CitedAccessToken | CitedRefreshToken,
     ) -> None:
-        if isinstance(token, CitedAccessToken):
-            self._access_tokens.pop(token.token, None)
-            # Also revoke refresh tokens for same client
-            to_remove = [
-                k for k, v in self._refresh_tokens.items()
-                if v.client_id == token.client_id
-            ]
-            for k in to_remove:
-                del self._refresh_tokens[k]
-        elif isinstance(token, CitedRefreshToken):
-            self._refresh_tokens.pop(token.token, None)
-            # Also revoke access tokens for same client
-            to_remove = [
-                k for k, v in self._access_tokens.items()
-                if v.client_id == token.client_id
-            ]
-            for k in to_remove:
-                del self._access_tokens[k]
+        # Stateless JWTs can't be revoked server-side without a blocklist.
+        # For this use case (Claude Desktop), explicit revocation is rare
+        # and tokens expire naturally.
+        logger.debug("Token revocation requested (no-op for stateless tokens)")
 
     # -- Helper: store auth code from callback --
 
@@ -270,7 +313,7 @@ class CitedOAuthProvider(
             redirect_uri=AnyUrl(redirect_uri),
             redirect_uri_provided_explicitly=redirect_uri_provided_explicitly,
             scopes=scopes,
-            expires_at=time.time() + 300,  # 5 minute expiry
+            expires_at=time.time() + 300,
             user_jwt=user_jwt,
             resource=resource,
         )

--- a/packages/mcp/src/cited_mcp/remote.py
+++ b/packages/mcp/src/cited_mcp/remote.py
@@ -74,8 +74,8 @@ def create_remote_server() -> FastMCP:
         lifespan=cited_remote_lifespan,
         auth_server_provider=auth_provider,
         auth=AuthSettings(
-            issuer_url=mcp_url,
-            resource_server_url=mcp_url,
+            issuer_url=mcp_url,  # type: ignore[arg-type]
+            resource_server_url=mcp_url,  # type: ignore[arg-type]
             client_registration_options=ClientRegistrationOptions(
                 enabled=True,
                 valid_scopes=["cited"],
@@ -89,7 +89,7 @@ def create_remote_server() -> FastMCP:
     server_module.mcp = remote_mcp
 
     # Register the OAuth callback route (handles redirect from backend)
-    @remote_mcp.custom_route("/oauth/callback", methods=["GET"])
+    @remote_mcp.custom_route("/oauth/callback", methods=["GET"])  # type: ignore[untyped-decorator]
     async def oauth_callback(request: Request) -> Response:
         """Handle callback from the Cited backend after user authentication."""
         user_token = request.query_params.get("token")
@@ -137,7 +137,7 @@ def create_remote_server() -> FastMCP:
         )
         return RedirectResponse(url=redirect_uri, status_code=302)
 
-    @remote_mcp.custom_route("/health", methods=["GET"])
+    @remote_mcp.custom_route("/health", methods=["GET"])  # type: ignore[untyped-decorator]
     async def health_check(request: Request) -> Response:
         return JSONResponse({"status": "ok"})
 

--- a/packages/mcp/src/cited_mcp/remote.py
+++ b/packages/mcp/src/cited_mcp/remote.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import logging
+import os
+import secrets
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import jwt
+from mcp.server.auth.middleware.auth_context import get_access_token
+from mcp.server.auth.provider import construct_redirect_uri
+from mcp.server.auth.settings import AuthSettings, ClientRegistrationOptions, RevocationOptions
+from mcp.server.fastmcp import FastMCP
+from starlette.requests import Request
+from starlette.responses import JSONResponse, RedirectResponse, Response
+
+from cited_core.api.client import CitedClient
+from cited_mcp.auth_provider import CitedAccessToken, CitedOAuthProvider
+from cited_mcp.context import CitedContext
+
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def cited_remote_lifespan(server: FastMCP) -> AsyncIterator[CitedContext]:
+    """Lifespan for the remote MCP server.
+
+    Unlike the stdio lifespan, the remote server doesn't have a pre-configured
+    token. The per-user JWT comes from the OAuth access token at request time
+    via get_access_token(). The lifespan provides a base context with no token.
+    """
+    api_url = os.environ.get("CITED_API_URL", "https://api.youcited.com")
+    env = os.environ.get("CITED_ENV", "prod")
+
+    client = CitedClient(base_url=api_url, token=None)
+    try:
+        yield CitedContext(client=client, env=env, api_url=api_url)
+    finally:
+        client.close()
+
+
+def get_user_client(api_url: str) -> CitedClient | None:
+    """Create a CitedClient using the authenticated user's JWT from OAuth context.
+
+    Tools can call this to get a client authenticated as the current user.
+    """
+    access_token = get_access_token()
+    if not access_token or not isinstance(access_token, CitedAccessToken):
+        return None
+    return CitedClient(base_url=api_url, token=access_token.user_jwt)
+
+
+def create_remote_server() -> FastMCP:
+    """Create and configure the remote MCP server with OAuth auth."""
+    import cited_mcp.server as server_module
+
+    backend_url = os.environ.get("CITED_API_URL", "https://api.youcited.com")
+    mcp_url = os.environ.get("MCP_URL", "https://mcp.youcited.com")
+    jwt_secret = os.environ["JWT_SECRET"]
+    host = os.environ.get("HOST", "0.0.0.0")
+    port = int(os.environ.get("PORT", "8080"))
+
+    auth_provider = CitedOAuthProvider(
+        backend_url=backend_url,
+        mcp_url=mcp_url,
+        jwt_secret=jwt_secret,
+    )
+
+    remote_mcp = FastMCP(
+        "cited",
+        instructions="Cited GEO platform — audit, optimize, and monitor AI search presence",
+        host=host,
+        port=port,
+        lifespan=cited_remote_lifespan,
+        auth_server_provider=auth_provider,
+        auth=AuthSettings(
+            issuer_url=mcp_url,
+            resource_server_url=mcp_url,
+            client_registration_options=ClientRegistrationOptions(
+                enabled=True,
+                valid_scopes=["cited"],
+                default_scopes=["cited"],
+            ),
+            revocation_options=RevocationOptions(enabled=True),
+        ),
+    )
+
+    # Set the module-level mcp instance so tool modules register on it
+    server_module.mcp = remote_mcp
+
+    # Register the OAuth callback route (handles redirect from backend)
+    @remote_mcp.custom_route("/oauth/callback", methods=["GET"])
+    async def oauth_callback(request: Request) -> Response:
+        """Handle callback from the Cited backend after user authentication."""
+        user_token = request.query_params.get("token")
+        state_jwt = request.query_params.get("state")
+
+        if not user_token or not state_jwt:
+            return JSONResponse(
+                {"error": "Missing token or state parameter"},
+                status_code=400,
+            )
+
+        try:
+            state = jwt.decode(state_jwt, jwt_secret, algorithms=["HS256"])
+        except jwt.ExpiredSignatureError:
+            return JSONResponse(
+                {"error": "Authorization state expired. Please try again."},
+                status_code=400,
+            )
+        except jwt.InvalidTokenError:
+            return JSONResponse(
+                {"error": "Invalid authorization state."},
+                status_code=400,
+            )
+
+        # Generate authorization code and store it
+        code = secrets.token_urlsafe(32)
+        auth_provider.store_auth_code(
+            code=code,
+            user_jwt=user_token,
+            client_id=state["client_id"],
+            code_challenge=state["code_challenge"],
+            redirect_uri=state["redirect_uri"],
+            redirect_uri_provided_explicitly=state.get(
+                "redirect_uri_provided_explicitly", True
+            ),
+            scopes=state.get("scopes", []),
+            resource=state.get("resource"),
+        )
+
+        # Redirect to Claude Desktop's redirect URI with the auth code
+        redirect_uri = construct_redirect_uri(
+            state["redirect_uri"],
+            code=code,
+            state=state.get("original_state"),
+        )
+        return RedirectResponse(url=redirect_uri, status_code=302)
+
+    @remote_mcp.custom_route("/health", methods=["GET"])
+    async def health_check(request: Request) -> Response:
+        return JSONResponse({"status": "ok"})
+
+    # Now import tools — they'll register on remote_mcp via server_module.mcp
+    server_module.register_tools()
+
+    return remote_mcp
+
+
+def run_remote_server() -> None:
+    """Start the remote MCP server with Streamable HTTP transport and OAuth."""
+    if "JWT_SECRET" not in os.environ:
+        raise SystemExit("JWT_SECRET environment variable is required")
+    server = create_remote_server()
+    server.run(transport="streamable-http")
+
+
+if __name__ == "__main__":
+    run_remote_server()

--- a/packages/mcp/src/cited_mcp/server.py
+++ b/packages/mcp/src/cited_mcp/server.py
@@ -11,10 +11,18 @@ from cited_core.auth.store import TokenStore
 from cited_core.config.manager import ConfigManager
 from cited_mcp.context import CitedContext
 
+# Module-level MCP instance. Tool modules import this via:
+#   from cited_mcp.server import mcp
+# and register tools with @mcp.tool().
+#
+# For stdio: set by run_server() before tool imports.
+# For remote: set by remote.py before tool imports.
+mcp: FastMCP = None  # type: ignore[assignment]
+
 
 @asynccontextmanager
 async def cited_lifespan(server: FastMCP) -> AsyncIterator[CitedContext]:
-    """Set up CitedClient for the MCP server lifetime."""
+    """Set up CitedClient for the MCP server lifetime (stdio transport)."""
     config = ConfigManager()
     env_override = os.environ.get("CITED_ENV")
     env = config.get_environment(override=env_override)
@@ -34,21 +42,36 @@ async def cited_lifespan(server: FastMCP) -> AsyncIterator[CitedContext]:
         client.close()
 
 
-mcp = FastMCP(
-    "cited",
-    instructions="Cited GEO platform — audit, optimize, and monitor AI search presence",
-    lifespan=cited_lifespan,
-)
+def register_tools() -> None:
+    """Import tool modules to trigger @mcp.tool() registrations.
 
-# Import tool modules to trigger @mcp.tool() registrations
-import cited_mcp.tools.auth  # noqa: I001, E402, F401
-import cited_mcp.tools.audit  # noqa: E402, F401
-import cited_mcp.tools.business  # noqa: E402, F401
-import cited_mcp.tools.job  # noqa: E402, F401
-import cited_mcp.tools.recommend  # noqa: E402, F401
-import cited_mcp.tools.solution  # noqa: E402, F401
+    Must be called after `cited_mcp.server.mcp` is set to a valid FastMCP instance.
+    """
+    import cited_mcp.tools.auth  # noqa: I001, E402, F401
+    import cited_mcp.tools.audit  # noqa: E402, F401
+    import cited_mcp.tools.business  # noqa: E402, F401
+    import cited_mcp.tools.job  # noqa: E402, F401
+    import cited_mcp.tools.recommend  # noqa: E402, F401
+    import cited_mcp.tools.solution  # noqa: E402, F401
+
+
+def create_stdio_server() -> FastMCP:
+    """Create the stdio MCP server and register all tools.
+
+    Sets the module-level `mcp` variable so tool modules can find it.
+    """
+    import cited_mcp.server as _self
+
+    _self.mcp = FastMCP(
+        "cited",
+        instructions="Cited GEO platform — audit, optimize, and monitor AI search presence",
+        lifespan=cited_lifespan,
+    )
+    register_tools()
+    return _self.mcp
 
 
 def run_server() -> None:
     """Start the MCP server on stdio transport."""
-    mcp.run(transport="stdio")
+    server = create_stdio_server()
+    server.run(transport="stdio")

--- a/packages/mcp/src/cited_mcp/tools/_helpers.py
+++ b/packages/mcp/src/cited_mcp/tools/_helpers.py
@@ -4,13 +4,39 @@ from typing import Any
 
 from mcp.server.fastmcp import Context
 
+from cited_core.api.client import CitedClient
 from cited_core.errors import CitedAPIError
 from cited_mcp.context import CitedContext
 
 
 def _get_ctx(ctx: Context[Any, CitedContext, Any]) -> CitedContext:
-    """Extract CitedContext from MCP lifespan context."""
+    """Extract CitedContext from MCP lifespan context.
+
+    For remote transport (OAuth), replaces the lifespan client with a per-request
+    client that carries the authenticated user's JWT.
+    """
     lc: CitedContext = ctx.request_context.lifespan_context
+
+    # If lifespan client already has a token (stdio transport), return as-is
+    if lc.client.token:
+        return lc
+
+    # Remote transport: try to get user JWT from OAuth access token
+    try:
+        from mcp.server.auth.middleware.auth_context import get_access_token
+
+        from cited_mcp.auth_provider import CitedAccessToken
+
+        access_token = get_access_token()
+        if access_token and isinstance(access_token, CitedAccessToken):
+            user_client = CitedClient(
+                base_url=lc.api_url,
+                token=access_token.user_jwt,
+            )
+            return CitedContext(client=user_client, env=lc.env, api_url=lc.api_url)
+    except ImportError:
+        pass
+
     return lc
 
 

--- a/packages/mcp/src/cited_mcp/tools/audit.py
+++ b/packages/mcp/src/cited_mcp/tools/audit.py
@@ -61,7 +61,7 @@ async def create_audit_template(
     if description is not None:
         payload["description"] = description
     if questions is not None:
-        payload["questions"] = questions
+        payload["questions"] = [{"question": q} for q in questions]
     try:
         return cited_ctx.client.post(endpoints.NAMED_AUDITS, json=payload)
     except CitedAPIError as e:
@@ -94,7 +94,7 @@ async def update_audit_template(
     if description is not None:
         payload["description"] = description
     if questions is not None:
-        payload["questions"] = questions
+        payload["questions"] = [{"question": q} for q in questions]
     try:
         return cited_ctx.client.put(
             endpoints.NAMED_AUDIT.format(named_audit_id=named_audit_id), json=payload

--- a/packages/mcp/src/cited_mcp/tools/auth.py
+++ b/packages/mcp/src/cited_mcp/tools/auth.py
@@ -32,11 +32,26 @@ async def check_auth_status(ctx: Context[Any, CitedContext, Any]) -> Any:
 async def login(ctx: Context[Any, CitedContext, Any], env: str | None = None) -> Any:
     """Log in to Cited by opening a browser window for OAuth authentication.
 
+    In remote mode (HTTP transport), authentication is handled automatically via
+    OAuth — this tool is only needed for stdio transport.
+
     Args:
         ctx: MCP context
         env: Optional environment override (dev, prod, local)
     """
     cited_ctx = _get_ctx(ctx)
+
+    # If already authenticated (e.g. remote mode with OAuth), skip login
+    if cited_ctx.client.token:
+        try:
+            user = cited_ctx.client.get(endpoints.ME)
+            return {
+                "success": True,
+                "message": f"Already authenticated as {user.get('email', 'unknown')}",
+            }
+        except CitedAPIError:
+            pass  # Token invalid, proceed with login flow
+
     target_env = env or cited_ctx.env
 
     callback_server = OAuthCallbackServer(timeout=120.0)

--- a/scripts/deploy-mcp.sh
+++ b/scripts/deploy-mcp.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deploy the remote MCP server to AWS ECS Fargate.
+#
+# Uses the existing ECS cluster and ALB from the cited backend infrastructure.
+# Creates its own ECR repo, target group, listener rule, task definition, and
+# ECS service — all via AWS CLI (no CDK dependency).
+#
+# Usage:
+#   ./scripts/deploy-mcp.sh dev     # Deploy to dev (mcpdev.youcited.com)
+#   ./scripts/deploy-mcp.sh prod    # Deploy to prod (mcp.youcited.com)
+#
+# Prerequisites:
+#   - AWS SSO session: aws sso login --profile advgeo-<env>
+#   - Docker running locally
+#   - SSM params from the cited backend CDK (VPC, cluster, ALB, etc.)
+
+ENV="${1:-}"
+if [[ -z "$ENV" || ! "$ENV" =~ ^(dev|prod)$ ]]; then
+    echo "Usage: $0 <dev|prod>"
+    exit 1
+fi
+
+PROFILE="advgeo-${ENV}"
+REGION="us-east-1"
+SERVICE_NAME="cited-mcp-${ENV}"
+CONTAINER_NAME="cited-mcp"
+CONTAINER_PORT=8080
+CPU=256
+MEMORY=512
+
+# Environment-specific config
+if [[ "$ENV" == "dev" ]]; then
+    MCP_URL="https://mcpdev.youcited.com"
+    API_URL="https://dev.youcited.com"
+    MCP_HOST="mcpdev.youcited.com"
+else
+    MCP_URL="https://mcp.youcited.com"
+    API_URL="https://api.youcited.com"
+    MCP_HOST="mcp.youcited.com"
+fi
+
+echo "==> Deploying MCP server to ${ENV} (${MCP_HOST})"
+
+# ── Resolve SSM parameters from existing infra ──────────────────────────────
+echo "    Resolving infrastructure parameters..."
+ssm() { aws --profile "$PROFILE" --region "$REGION" ssm get-parameter --name "$1" --query Parameter.Value --output text; }
+
+VPC_ID=$(ssm "/advgeo/${ENV}/vpc-id")
+SUBNET_IDS=$(ssm "/advgeo/${ENV}/private-subnet-ids")
+ECS_CLUSTER=$(ssm "/advgeo/${ENV}/ecs-cluster-arn")
+ECS_SG=$(ssm "/advgeo/${ENV}/ecs-security-group-id")
+HTTPS_LISTENER=$(ssm "/advgeo/${ENV}/https-listener-arn")
+ACCOUNT_ID=$(aws --profile "$PROFILE" sts get-caller-identity --query Account --output text)
+
+echo "    VPC: ${VPC_ID}"
+echo "    Cluster: ${ECS_CLUSTER}"
+
+# ── ECR repository ──────────────────────────────────────────────────────────
+ECR_REPO="${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/${SERVICE_NAME}"
+
+if ! aws --profile "$PROFILE" --region "$REGION" ecr describe-repositories --repository-names "$SERVICE_NAME" &>/dev/null; then
+    echo "    Creating ECR repository: ${SERVICE_NAME}"
+    aws --profile "$PROFILE" --region "$REGION" ecr create-repository \
+        --repository-name "$SERVICE_NAME" \
+        --image-scanning-configuration scanOnPush=true \
+        --query 'repository.repositoryUri' --output text
+else
+    echo "    ECR repository exists: ${SERVICE_NAME}"
+fi
+
+# ── Build and push Docker image ─────────────────────────────────────────────
+echo "==> Building Docker image..."
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Build from repo root so COPY paths work
+docker build --platform linux/amd64 -t "${SERVICE_NAME}:latest" \
+    -f "${REPO_ROOT}/packages/mcp/Dockerfile" \
+    "${REPO_ROOT}"
+
+echo "==> Pushing to ECR..."
+aws --profile "$PROFILE" --region "$REGION" ecr get-login-password | \
+    docker login --username AWS --password-stdin "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com"
+
+docker tag "${SERVICE_NAME}:latest" "${ECR_REPO}:latest"
+docker push "${ECR_REPO}:latest"
+IMAGE_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "${ECR_REPO}:latest" 2>/dev/null || echo "${ECR_REPO}:latest")
+
+# ── Target group ────────────────────────────────────────────────────────────
+TG_NAME="${SERVICE_NAME}-tg"
+TG_ARN=$(aws --profile "$PROFILE" --region "$REGION" elbv2 describe-target-groups \
+    --names "$TG_NAME" --query "TargetGroups[0].TargetGroupArn" --output text 2>/dev/null || echo "None")
+
+if [[ "$TG_ARN" == "None" || -z "$TG_ARN" ]]; then
+    echo "    Creating target group: ${TG_NAME}"
+    TG_ARN=$(aws --profile "$PROFILE" --region "$REGION" elbv2 create-target-group \
+        --name "$TG_NAME" \
+        --protocol HTTP \
+        --port "$CONTAINER_PORT" \
+        --vpc-id "$VPC_ID" \
+        --target-type ip \
+        --health-check-path "/health" \
+        --health-check-interval-seconds 30 \
+        --healthy-threshold-count 2 \
+        --unhealthy-threshold-count 3 \
+        --query "TargetGroups[0].TargetGroupArn" --output text)
+else
+    echo "    Target group exists: ${TG_NAME}"
+fi
+
+# ── ALB listener rule (host-header based) ───────────────────────────────────
+RULE_EXISTS=$(aws --profile "$PROFILE" --region "$REGION" elbv2 describe-rules \
+    --listener-arn "$HTTPS_LISTENER" \
+    --query "Rules[?Conditions[?Field=='host-header' && Values[?contains(@,'${MCP_HOST}')]]]|[0].RuleArn" \
+    --output text 2>/dev/null || echo "None")
+
+if [[ "$RULE_EXISTS" == "None" || -z "$RULE_EXISTS" ]]; then
+    echo "    Creating listener rule for ${MCP_HOST}"
+    aws --profile "$PROFILE" --region "$REGION" elbv2 create-rule \
+        --listener-arn "$HTTPS_LISTENER" \
+        --priority 1 \
+        --conditions "Field=host-header,Values=${MCP_HOST}" \
+        --actions "Type=forward,TargetGroupArn=${TG_ARN}" \
+        --query "Rules[0].RuleArn" --output text
+else
+    echo "    Listener rule exists for ${MCP_HOST}"
+fi
+
+# ── Resolve JWT secret ARN ──────────────────────────────────────────────────
+JWT_SECRET_ARN=$(aws --profile "$PROFILE" --region "$REGION" secretsmanager list-secrets \
+    --filters "Key=name,Values=advgeo/${ENV}/jwt-secret" \
+    --query "SecretList[0].ARN" --output text)
+echo "    JWT secret: ${JWT_SECRET_ARN}"
+
+# ── IAM roles (reuse existing execution role, create minimal task role) ─────
+# Get execution role from existing API task definition
+API_TASKDEF=$(aws --profile "$PROFILE" --region "$REGION" ecs describe-services \
+    --cluster advgeo-${ENV} --services advgeo-${ENV}-api \
+    --query "services[0].taskDefinition" --output text)
+EXEC_ROLE=$(aws --profile "$PROFILE" --region "$REGION" ecs describe-task-definition \
+    --task-definition "$API_TASKDEF" \
+    --query "taskDefinition.executionRoleArn" --output text)
+TASK_ROLE=$(aws --profile "$PROFILE" --region "$REGION" ecs describe-task-definition \
+    --task-definition "$API_TASKDEF" \
+    --query "taskDefinition.taskRoleArn" --output text)
+
+# ── ECS task definition ─────────────────────────────────────────────────────
+echo "==> Registering task definition..."
+TASKDEF_FILE=$(mktemp)
+cat > "$TASKDEF_FILE" <<EOF
+{
+    "family": "${SERVICE_NAME}",
+    "networkMode": "awsvpc",
+    "requiresCompatibilities": ["FARGATE"],
+    "cpu": "${CPU}",
+    "memory": "${MEMORY}",
+    "executionRoleArn": "${EXEC_ROLE}",
+    "taskRoleArn": "${TASK_ROLE}",
+    "containerDefinitions": [
+        {
+            "name": "${CONTAINER_NAME}",
+            "image": "${ECR_REPO}:latest",
+            "essential": true,
+            "portMappings": [
+                {
+                    "containerPort": ${CONTAINER_PORT},
+                    "protocol": "tcp"
+                }
+            ],
+            "environment": [
+                {"name": "CITED_API_URL", "value": "${API_URL}"},
+                {"name": "MCP_URL", "value": "${MCP_URL}"},
+                {"name": "CITED_ENV", "value": "${ENV}"},
+                {"name": "HOST", "value": "0.0.0.0"},
+                {"name": "PORT", "value": "${CONTAINER_PORT}"}
+            ],
+            "secrets": [
+                {"name": "JWT_SECRET", "valueFrom": "${JWT_SECRET_ARN}"}
+            ],
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-group": "/ecs/advgeo-${ENV}",
+                    "awslogs-region": "${REGION}",
+                    "awslogs-stream-prefix": "mcp"
+                }
+            }
+        }
+    ]
+}
+EOF
+
+TASKDEF_ARN=$(aws --profile "$PROFILE" --region "$REGION" ecs register-task-definition \
+    --cli-input-json "file://${TASKDEF_FILE}" \
+    --query "taskDefinition.taskDefinitionArn" --output text)
+rm -f "$TASKDEF_FILE"
+echo "    Task definition: ${TASKDEF_ARN}"
+
+# ── ECS service ─────────────────────────────────────────────────────────────
+SERVICE_EXISTS=$(aws --profile "$PROFILE" --region "$REGION" ecs describe-services \
+    --cluster "advgeo-${ENV}" --services "$SERVICE_NAME" \
+    --query "services[?status=='ACTIVE']|[0].serviceName" --output text 2>/dev/null || echo "None")
+
+# Format subnet IDs for JSON array
+IFS=',' read -ra SUBNET_ARR <<< "$SUBNET_IDS"
+SUBNET_JSON=$(printf '"%s",' "${SUBNET_ARR[@]}" | sed 's/,$//')
+
+if [[ "$SERVICE_EXISTS" == "None" || -z "$SERVICE_EXISTS" ]]; then
+    echo "==> Creating ECS service: ${SERVICE_NAME}"
+    aws --profile "$PROFILE" --region "$REGION" ecs create-service \
+        --cluster "advgeo-${ENV}" \
+        --service-name "$SERVICE_NAME" \
+        --task-definition "$TASKDEF_ARN" \
+        --desired-count 1 \
+        --launch-type FARGATE \
+        --network-configuration "awsvpcConfiguration={subnets=[${SUBNET_JSON}],securityGroups=[\"${ECS_SG}\"],assignPublicIp=DISABLED}" \
+        --load-balancers "targetGroupArn=${TG_ARN},containerName=${CONTAINER_NAME},containerPort=${CONTAINER_PORT}" \
+        --deployment-configuration "maximumPercent=200,minimumHealthyPercent=100,deploymentCircuitBreaker={enable=true,rollback=true}" \
+        --query "service.serviceName" --output text
+else
+    echo "==> Updating ECS service: ${SERVICE_NAME}"
+    aws --profile "$PROFILE" --region "$REGION" ecs update-service \
+        --cluster "advgeo-${ENV}" \
+        --service "$SERVICE_NAME" \
+        --task-definition "$TASKDEF_ARN" \
+        --force-new-deployment \
+        --query "service.serviceName" --output text
+fi
+
+echo ""
+echo "==> Deployment initiated!"
+echo "    Service: ${SERVICE_NAME}"
+echo "    URL: ${MCP_URL}"
+echo ""
+echo "    Waiting for service to stabilize..."
+aws --profile "$PROFILE" --region "$REGION" ecs wait services-stable \
+    --cluster "advgeo-${ENV}" --services "$SERVICE_NAME" && \
+    echo "    ✓ Service is stable!" || \
+    echo "    ⚠ Service did not stabilize within timeout. Check ECS console."
+
+echo ""
+echo "    Next steps:"
+echo "    1. Add DNS CNAME: ${MCP_HOST} → ALB DNS name"
+echo "    2. Test: curl https://${MCP_HOST}/health"
+echo "    3. Claude Desktop config: {\"type\": \"http\", \"url\": \"${MCP_URL}\"}"

--- a/src/cited_cli/commands/auth.py
+++ b/src/cited_cli/commands/auth.py
@@ -59,20 +59,25 @@ def _browser_auth(
     *, mode: str = "login",
 ) -> None:
     import webbrowser
+    from urllib.parse import urlencode
 
-    from cited_cli.auth.oauth_server import OAuthCallbackServer
+    from cited_core.auth.oauth_server import OAuthCallbackServer
 
-    server = OAuthCallbackServer(timeout=120)
-    server.start()
+    callback_server = OAuthCallbackServer(timeout=120)
+    callback_server.start()
 
-    client = CitedClient(base_url=api_url)
     try:
-        payload: dict[str, str] = {"redirect_uri": server.redirect_uri, "mode": mode}
+        # Build the authorize-app URL — the backend handles login/consent/redirect
+        params: dict[str, str] = {
+            "callback": callback_server.redirect_uri,
+            "app_name": "cited-cli",
+        }
         if provider:
-            payload["provider"] = provider
+            params["provider"] = provider
+        if mode == "register":
+            params["mode"] = "register"
 
-        response = client.post(endpoints.CLI_OAUTH_START, json=payload)
-        auth_url = response["auth_url"]
+        auth_url = f"{api_url}{endpoints.AUTHORIZE_APP}?{urlencode(params)}"
 
         action = "registration" if mode == "register" else "login"
         label = f"{provider} {action}" if provider else action
@@ -83,7 +88,7 @@ def _browser_auth(
             )
         out.console.print("[dim]Waiting for authentication...[/dim]")
 
-        token = server.wait_for_token()
+        token = callback_server.wait_for_token()
         if not token:
             # Paste fallback for environments where localhost callback fails
             if is_interactive():
@@ -107,11 +112,8 @@ def _browser_auth(
         via = f" via {provider}" if provider else ""
         success_msg = "Registered" if mode == "register" else "Logged in"
         print_success(f"{success_msg} on {env}{via}", out)
-    except CitedAPIError as e:
-        handle_api_error(e, out.json_mode)
     finally:
-        server.shutdown()
-        client.close()
+        callback_server.shutdown()
 
 
 def _password_register(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,22 @@ from typer.testing import CliRunner
 from cited_cli.app import app
 
 
+def pytest_addoption(parser):
+    parser.addoption("--live", action="store_true", default=False, help="Run live integration tests")
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "live: mark test as live integration test (requires --live)")
+
+
+def pytest_collection_modifyitems(config, items):
+    if not config.getoption("--live"):
+        skip_live = pytest.mark.skip(reason="need --live option to run")
+        for item in items:
+            if "live" in item.keywords:
+                item.add_marker(skip_live)
+
+
 @pytest.fixture
 def runner() -> CliRunner:
     return CliRunner()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -62,29 +62,23 @@ def test_login_password_flow(runner, cli_app, tmp_path, monkeypatch):
     assert creds["prod"] == "fake-jwt-token"
 
 
-@respx.mock
 def test_login_browser_flow(runner, cli_app, tmp_path, monkeypatch):
-    """Browser login starts OAuth server, opens browser, receives token via callback."""
+    """Browser login opens /auth/authorize-app URL, receives token via callback."""
     _, creds_file = _setup_tmp_config(tmp_path, monkeypatch)
 
-    # Capture the redirect_uri from the request so we can send a token to it
-    captured_redirect_uri = {}
-
-    def mock_oauth_start(request):
-        body = json.loads(request.content)
-        captured_redirect_uri["uri"] = body["redirect_uri"]
-        return httpx.Response(200, json={"auth_url": "https://accounts.google.com/auth"})
-
-    respx.post("https://api.youcited.com/auth/cli-oauth-start").mock(
-        side_effect=mock_oauth_start
-    )
-
-    # Mock webbrowser.open to instead send a token to the callback server
+    # Mock webbrowser.open to extract the callback URI from the authorize-app URL
+    # and send a token directly to the localhost callback server
     def fake_browser_open(url):
-        # Give the server a moment, then send the token callback
+        from urllib.parse import parse_qs, urlparse
+
+        assert "/auth/authorize-app" in url
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+        assert "google" in params.get("provider", [""])[0]
+        callback_uri = params["callback"][0]
+
         def send_callback():
-            uri = captured_redirect_uri["uri"]
-            callback_url = f"{uri}?token=browser-jwt-token"
+            callback_url = f"{callback_uri}?token=browser-jwt-token"
             urllib.request.urlopen(callback_url, timeout=5)  # noqa: S310
 
         threading.Thread(target=send_callback, daemon=True).start()
@@ -278,26 +272,22 @@ def test_top_level_register(runner, cli_app, tmp_path, monkeypatch):
     assert creds["prod"] == "top-register-jwt"
 
 
-@respx.mock
 def test_register_browser_flow(runner, cli_app, tmp_path, monkeypatch):
-    """Browser registration sends mode=register in cli-oauth-start payload."""
+    """Browser registration passes mode=register in authorize-app URL."""
     _, creds_file = _setup_tmp_config(tmp_path, monkeypatch)
 
-    captured_payload = {}
-
-    def mock_oauth_start(request):
-        body = json.loads(request.content)
-        captured_payload.update(body)
-        return httpx.Response(200, json={"auth_url": "https://accounts.google.com/auth"})
-
-    respx.post("https://api.youcited.com/auth/cli-oauth-start").mock(
-        side_effect=mock_oauth_start
-    )
+    captured_url = {}
 
     def fake_browser_open(url):
+        from urllib.parse import parse_qs, urlparse
+
+        captured_url["url"] = url
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+        callback_uri = params["callback"][0]
+
         def send_callback():
-            uri = captured_payload["redirect_uri"]
-            callback_url = f"{uri}?token=register-browser-jwt"
+            callback_url = f"{callback_uri}?token=register-browser-jwt"
             urllib.request.urlopen(callback_url, timeout=5)  # noqa: S310
 
         threading.Thread(target=send_callback, daemon=True).start()
@@ -312,7 +302,13 @@ def test_register_browser_flow(runner, cli_app, tmp_path, monkeypatch):
     )
     assert result.exit_code == 0
     assert "Registered" in result.output
-    assert captured_payload.get("mode") == "register"
+
+    # Verify mode=register was passed in the authorize-app URL
+    from urllib.parse import parse_qs, urlparse
+
+    parsed = urlparse(captured_url["url"])
+    params = parse_qs(parsed.query)
+    assert params.get("mode") == ["register"]
 
     creds = json.loads(creds_file.read_text())
     assert creds["prod"] == "register-browser-jwt"
@@ -344,21 +340,16 @@ def test_register_password_mismatch(runner, cli_app, tmp_path, monkeypatch):
     assert "do not match" in result.output.lower() or "Passwords" in result.output
 
 
-@respx.mock
 def test_paste_fallback(runner, cli_app, tmp_path, monkeypatch):
     """When browser callback times out, user can paste token manually."""
     _, creds_file = _setup_tmp_config(tmp_path, monkeypatch)
-
-    respx.post("https://api.youcited.com/auth/cli-oauth-start").mock(
-        return_value=httpx.Response(200, json={"auth_url": "https://example.com/auth"})
-    )
 
     # Mock webbrowser.open to do nothing (simulates browser opening but no callback)
     monkeypatch.setattr("webbrowser.open", lambda url: True)
 
     # Mock OAuthCallbackServer.wait_for_token to return None (timeout)
     monkeypatch.setattr(
-        "cited_cli.auth.oauth_server.OAuthCallbackServer.wait_for_token",
+        "cited_core.auth.oauth_server.OAuthCallbackServer.wait_for_token",
         lambda self: None,
     )
 

--- a/tests/test_live_pipeline.py
+++ b/tests/test_live_pipeline.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from cited_core.api.client import CitedClient
+from cited_core.auth.store import TokenStore
+from cited_mcp.context import CitedContext
+
+DEV_API = "https://dev.youcited.com"
+
+pytestmark = pytest.mark.live
+
+
+def _make_cited_ctx(token: str) -> CitedContext:
+    client = CitedClient(base_url=DEV_API, token=token)
+    return CitedContext(client=client, env="dev", api_url=DEV_API)
+
+
+def _make_mcp_ctx(cited_ctx: CitedContext) -> Any:
+    ctx = MagicMock()
+    ctx.request_context.lifespan_context = cited_ctx
+    return ctx
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _ensure_mcp_initialized() -> None:
+    """Ensure the MCP server instance exists so @mcp.tool() decorators work."""
+    import cited_mcp.server as _mcp_server
+
+    if _mcp_server.mcp is None:
+        from mcp.server.fastmcp import FastMCP
+
+        _mcp_server.mcp = FastMCP("cited-test")
+        _mcp_server.register_tools()
+
+
+def _get_token() -> str | None:
+    token = os.environ.get("CITED_TOKEN")
+    if token:
+        return token
+    try:
+        return TokenStore().get_token("dev")
+    except Exception:
+        return None
+
+
+def _poll_until_complete(
+    cited_ctx: CitedContext,
+    job_type: str,
+    job_id: str,
+    timeout: int = 300,
+) -> dict[str, Any]:
+    """Poll job status until completed or timeout."""
+    from cited_core.api import endpoints
+
+    endpoint_map = {
+        "audit": endpoints.AUDIT_STATUS,
+        "recommendation": endpoints.RECOMMEND_STATUS,
+        "solution": endpoints.SOLUTION_STATUS,
+    }
+    endpoint = endpoint_map[job_type].format(job_id=job_id)
+    start = time.time()
+    while time.time() - start < timeout:
+        result = cited_ctx.client.get(endpoint)
+        status = result.get("status")
+        if status == "completed":
+            return result
+        if status in ("failed", "cancelled"):
+            pytest.fail(f"{job_type} job {job_id} {status}: {result}")
+        time.sleep(5)
+    pytest.fail(f"{job_type} job {job_id} timed out after {timeout}s")
+
+
+def test_full_live_pipeline():
+    """Full customer journey against the live dev API."""
+    _ensure_mcp_initialized()
+
+    from cited_mcp.tools.auth import check_auth_status
+    from cited_mcp.tools.audit import create_audit_template, start_audit, get_audit_result
+    from cited_mcp.tools.business import (
+        create_business,
+        delete_business,
+        get_health_scores,
+    )
+    from cited_mcp.tools.recommend import (
+        get_recommendation_insights,
+        start_recommendation,
+    )
+    from cited_mcp.tools.solution import get_solution_result, start_solution
+
+    token = _get_token()
+    if not token:
+        pytest.skip("No dev auth token available (set CITED_TOKEN or login to dev)")
+
+    cited_ctx = _make_cited_ctx(token)
+    ctx = _make_mcp_ctx(cited_ctx)
+    business_id = None
+    template_id = None
+
+    try:
+        # 1. Check auth status
+        auth = _run(check_auth_status(ctx))
+        assert "email" in auth, f"Auth check failed: {auth}"
+        print(f"\n  Auth: {auth['email']}")
+
+        # 2. Create a test business
+        biz = _run(
+            create_business(
+                ctx,
+                "MCP Integration Test Bakery",
+                "https://sunrisebakery.com",
+                "Integration test business for MCP pipeline validation. "
+                "Artisan bakery in Austin Texas specializing in sourdough and pastries.",
+                "restaurant",
+            )
+        )
+        assert "id" in biz, f"Business create failed: {biz}"
+        business_id = biz["id"]
+        print(f"  Business: {business_id}")
+
+        # 3. Get health scores (baseline, may be empty)
+        scores = _run(get_health_scores(ctx, business_id))
+        assert not isinstance(scores, dict) or not scores.get("error"), f"Health scores failed: {scores}"
+        print(f"  Health scores: {type(scores).__name__}")
+
+        # 4. Create audit template
+        template = _run(
+            create_audit_template(
+                ctx,
+                "MCP Test Audit",
+                business_id,
+                "Integration test audit template",
+                [
+                    "What is the best bakery in Austin Texas?",
+                    "Where can I find artisan sourdough bread near me?",
+                    "Best wedding cake bakeries in Austin",
+                ],
+            )
+        )
+        assert "id" in template, f"Template create failed: {template}"
+        template_id = template["id"]
+        print(f"  Template: {template_id}")
+
+        # 5. Start audit
+        audit = _run(start_audit(ctx, template_id, business_id))
+        assert "job_id" in audit, f"Audit start failed: {audit}"
+        audit_job_id = audit["job_id"]
+        print(f"  Audit job: {audit_job_id}")
+
+        # 6. Poll until audit completes
+        print("  Polling audit...", end="", flush=True)
+        _poll_until_complete(cited_ctx, "audit", audit_job_id, timeout=300)
+        print(" done")
+
+        # 7. Get audit result
+        audit_result = _run(get_audit_result(ctx, audit_job_id))
+        assert audit_result is not None
+        assert not (isinstance(audit_result, dict) and audit_result.get("error"))
+        print(f"  Audit result: OK")
+
+        # 8. Start recommendation
+        rec = _run(start_recommendation(ctx, audit_job_id))
+        assert "job_id" in rec, f"Recommendation start failed: {rec}"
+        rec_job_id = rec["job_id"]
+        print(f"  Recommendation job: {rec_job_id}")
+
+        # 9. Poll until recommendation completes
+        print("  Polling recommendation...", end="", flush=True)
+        _poll_until_complete(cited_ctx, "recommendation", rec_job_id, timeout=300)
+        print(" done")
+
+        # 10. Get recommendation insights
+        insights = _run(get_recommendation_insights(ctx, rec_job_id))
+        assert "question_insights" in insights, f"Insights failed: {insights}"
+        qi = insights["question_insights"]
+        print(f"  Insights: {len(qi)} question insights")
+
+        # Verify annotations are present
+        if qi:
+            assert "source_type" in qi[0], f"Missing source_type in insight: {qi[0]}"
+            assert "source_id" in qi[0], f"Missing source_id in insight: {qi[0]}"
+
+        # 11. Start solution from first question insight (if available)
+        if qi:
+            sol = _run(
+                start_solution(
+                    ctx, rec_job_id, qi[0]["source_type"], qi[0]["source_id"]
+                )
+            )
+            assert "job_id" in sol, f"Solution start failed: {sol}"
+            sol_job_id = sol["job_id"]
+            print(f"  Solution job: {sol_job_id}")
+
+            # 12. Poll until solution completes
+            print("  Polling solution...", end="", flush=True)
+            _poll_until_complete(cited_ctx, "solution", sol_job_id, timeout=300)
+            print(" done")
+
+            # 13. Get solution result
+            sol_result = _run(get_solution_result(ctx, sol_job_id))
+            assert sol_result is not None
+            assert not (isinstance(sol_result, dict) and sol_result.get("error"))
+            print(f"  Solution result: OK")
+
+        print("  Pipeline complete!")
+
+    finally:
+        # Cleanup: delete business (which cascades to templates, audits, etc.)
+        if business_id:
+            try:
+                _run(delete_business(ctx, business_id))
+                print(f"  Cleanup: deleted business {business_id}")
+            except Exception as e:
+                print(f"  Cleanup warning: failed to delete business {business_id}: {e}")
+        cited_ctx.client.close()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -45,8 +45,9 @@ EXPECTED_TOOLS = [
 
 @pytest.mark.usefixtures("_mcp_available")
 def test_all_tools_registered():
-    from cited_mcp.server import mcp
+    from cited_mcp.server import create_stdio_server
 
+    mcp = create_stdio_server()
     tool_names = [t.name for t in mcp._tool_manager.list_tools()]
     assert len(tool_names) == len(EXPECTED_TOOLS)
     for name in EXPECTED_TOOLS:
@@ -55,7 +56,8 @@ def test_all_tools_registered():
 
 @pytest.mark.usefixtures("_mcp_available")
 def test_all_tools_have_descriptions():
-    from cited_mcp.server import mcp
+    from cited_mcp.server import create_stdio_server
 
+    mcp = create_stdio_server()
     for tool in mcp._tool_manager.list_tools():
         assert tool.description, f"Tool {tool.name} has no description"


### PR DESCRIPTION
## Summary
- Remote MCP server deployed at `mcpdev.youcited.com` — Claude Desktop connects via `mcp-remote` proxy (zero install for end users beyond Node.js)
- Stateless JWT-based OAuth tokens that survive server restarts, deploys, and Fargate Spot reclaims
- Auto-accept unknown client IDs with PKCE security (no forced re-registration on redeploy)
- Fix OAuth scope validation: clients now persist/restore the `scope` field across all paths (JWT-reconstructed, auto-accepted, registered)
- Fix audit template question format to match backend `[{question: "..."}]` schema
- Add `--live` pytest marker and full end-to-end integration test covering auth → business → audit → recommendations → solutions

## Architecture
The MCP server acts as both an OAuth authorization server (for Claude Desktop) and a relay to the Cited backend API:
1. Claude Desktop → MCP `/authorize` → backend `/auth/authorize-app`
2. User authenticates in browser → backend redirects to MCP `/oauth/callback` with JWT
3. MCP issues stateless JWT access/refresh tokens to Claude Desktop
4. Claude Desktop calls MCP tools with Bearer token → MCP extracts user JWT for API calls

## Files changed
- `packages/mcp/src/cited_mcp/auth_provider.py` — Stateless JWT tokens, scope fix, permissive localhost client
- `packages/mcp/src/cited_mcp/tools/audit.py` — Question format fix
- `tests/conftest.py` — `--live` marker infrastructure
- `tests/test_live_pipeline.py` — Full pipeline integration test

## Test plan
- [x] `pytest tests/ -v` — 89 passed, 1 skipped
- [x] Deployed to dev (`mcpdev.youcited.com`) and tested end-to-end in Claude Desktop Cowork
- [x] Full flow verified: business create → crawl → audit template → audit → recommendations
- [ ] Deploy to prod (`mcp.youcited.com`) after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)