### PR TITLE
feat(plugins): cited:explore skill + when-to-call docstrings

### DIFF
--- a/cited-plugins/commands/status.md
+++ b/cited-plugins/commands/status.md
@@ -6,12 +6,18 @@ user_invocable: true
 
 Perform a quick status check of the user's Cited account:
 
-1. Call `ping` first. Note the `tools_fingerprint` and `server_version` in the response — keep them in mind for the rest of this conversation.
-   - **If you ran this skill earlier in this conversation** and the new `tools_fingerprint` differs from the value you stashed, the server's tool surface has changed since the user connected (likely a Cited release). Try calling `whats_new(since_fingerprint=<previous>)` and, if it succeeds, surface the additions, removals, and changed tools to the user before continuing.
-   - **If the call to `whats_new` fails for any reason** — the tool isn't registered yet (`Unknown tool`), returns a structured `tool_unavailable` error, returns any other error, or simply doesn't exist — do **not** surface that error to the user. Silently fall back to: "The MCP tool surface has changed since you connected. Disconnect and reconnect the Cited connector in your Claude Desktop / Claude.ai connector settings to pick up the latest tools."
-   - **If this is your first run in the conversation,** just stash the fingerprint and proceed.
+1. Call `ping`. Stash the `tools_fingerprint` and `server_version` from the response for the rest of this conversation.
+   - **First run this conversation:** stash the values and proceed.
+   - **Later run, fingerprint matches the stashed value:** nothing changed, proceed.
+   - **Later run, fingerprint differs:** the server's tool surface changed mid-conversation (a Cited release landed). Call `whats_new(since_fingerprint=<previous_fingerprint>, since_version=<previous_version>)` — this is the primary path, not best-effort — and surface its response to the user before continuing. The response shape determines what to surface:
+     - **Normal diff** — render `tools_added`, `tools_changed`, `tools_removed`. Each item carries `added_in_version` / `changed_in_version` / `removed_in_version`. If a top-level `_note` is present (e.g. the prior fingerprint predates the changelog), include it verbatim so the user knows the diff is unbounded.
+     - **`{"no_changes": true}`** — say "tool surface unchanged since last check" and move on.
+     - **`{"error": true, "error_type": "changelog_unavailable"}`** — surface the response's `message` field verbatim. The server is healthy but can't compute a diff right now; ping and the rest of the skill still work.
+     - **`{"error": true, "error_type": "tool_unavailable"}`** — only fires against a pre-0.3.5 server where `whats_new` isn't registered. Fall back to: "The MCP tool surface has changed since you connected. Disconnect and reconnect the Cited connector in your Claude Desktop / Claude.ai connector settings to pick up the latest tools."
 2. Call `check_auth_status` to verify authentication and show the logged-in user.
 3. Call `list_businesses` to show all businesses.
 4. Call `list_audits` to show recent audit activity.
 
 Present a concise summary of the user's current state on the Cited platform.
+
+For ad-hoc tool exploration beyond the standard audit flow — diagnostics, deltas, intel without re-running an audit, one-off probes — see `cited:explore`.

--- a/cited-plugins/skills/explore/SKILL.md
+++ b/cited-plugins/skills/explore/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: explore
+description: Ad-hoc tool exploration beyond the standard audit flow — diagnostics, comparisons, intel without re-running an audit, and one-off probes
+---
+
+# Explore Cited Beyond the Audit Flow
+
+The standard pipeline is `cited:business-setup` → `cited:geo-audit` → `cited:geo-recommend`. This skill covers the eleven tools that DON'T fit that pipeline — diagnostics, deltas, intel surfaces, ad-hoc probes — so you can answer "what changed since last week," "what does Cited know about this business," "would AI recommend us for X" without burning a fresh audit.
+
+If a tool returns `payment_required: true` with an `upgrade_tier` field, surface the upgrade message verbatim. Don't pretend the result was empty.
+
+## Per-tool reference
+
+### compare_audits — week-over-week regression detection
+
+When to use it: The user asks "what changed since the last audit" or "are we improving." Run this instead of summarizing two full audit reports back to back — it computes the diff for you.
+
+Recipe:
+1. `list_audits(business_id=<biz_id>, limit=10)` — pull recent audits, find two completed ones on the same `named_audit_id`.
+2. `compare_audits(audit_id=<recent_job_id>, baseline_id=<prior_job_id>)`.
+
+What to do with the response: `questions_comparison` is a per-question delta map — surface regressions first (questions where the score fell), wins second. `changes` is the aggregate KPI delta block — name the top 2-3 movers ("share of voice fell 12 points; coverage flat"). `baseline_audit` and `current_audit` echo the two records being compared so the user knows what timeframe.
+
+### cancel_job — recovery for hung or wrong-target jobs
+
+When to use it: A `get_*_status` call shows a job has been "running" far longer than expected (audits typically 2-4 min, recommendations 1-2 min, solutions 30-60s) OR the user realizes the job was started against the wrong template/business. Cancelling stops further plan-budget consumption.
+
+Recipe:
+1. `cancel_job(job_id=<id>)` — `job_type` auto-probes if omitted.
+
+What to do with the response: `{success, job_type, message}` on success, or a not-found error. Confirm the cancellation by job_type ("audit cancelled," not just "cancelled") and tell the user they can start a fresh job.
+
+### get_analytics_dashboard — combined analytics page (Pro)
+
+When to use it: The user asks for an overview of AI search performance — KPIs, trends, top/declining questions, citation patterns, benchmarks. One call covers what the web Analytics page shows.
+
+Recipe:
+1. `get_analytics_dashboard(business_id=<biz_id>)`.
+
+What to do with the response: Top-level fields are `kpi_trends` (time-series per KPI), `question_performance` (top + declining), `citation_trends` (match rates, domain diversity), `benchmarks` (vs. historical average), `domain_benchmarks` (per-domain severity). Lead the summary with `benchmarks` deltas; then the worst-trending KPI from `kpi_trends`; then the top declining questions.
+
+### get_analytics_trends — KPI time series only (Pro)
+
+When to use it: You only need the KPI time-series — e.g., for a chart, or to compute a custom trend. Cheaper than the dashboard if you don't need the rest.
+
+Recipe:
+1. `get_analytics_trends(business_id=<biz_id>)`.
+
+What to do with the response: `periods` is the x-axis (ordered date labels). `kpi_trends` maps KPI name → list of values aligned with `periods`. `summary` has aggregate stats. Plot or summarize the largest delta first.
+
+### get_business_facts — structured intel from the fact graph (Pro)
+
+When to use it: The user asks "what does Cited know about [business]" or you need structured intel (locations, products, summary) without running an audit. Cheap, no plan-budget impact. Pair with crawl_business if the data looks stale.
+
+Recipe:
+1. `get_business_facts(business_id=<biz_id>)`.
+
+What to do with the response: `name`, `summary`, `locations`, `products`, `facts`. Surface `summary` as the headline. If `summary` is null AND `facts` is empty, the fact graph is thin — recommend running `crawl_business` to populate (see "Cold-start business intel" below).
+
+### get_business_claims — verifiable claims with evidence (Pro)
+
+When to use it: Auditing brand truth-in-advertising, or surfacing claims that need stronger evidence before they appear in AI summaries. Useful when prepping a product page or a press kit.
+
+Recipe:
+1. `get_business_claims(business_id=<biz_id>)`.
+
+What to do with the response: `claims` is a list of statements with evidence references. Highlight claims with weak/absent evidence first — those are the ones to either substantiate or remove.
+
+### get_business_hq — comprehensive dashboard (Pro)
+
+When to use it: The user wants a one-shot snapshot of an account — health scores, recent audits, recommendations, competitive position, top action items. Reach for this when summarizing an account holistically rather than answering a narrow question.
+
+Recipe:
+1. `get_business_hq(business_id=<biz_id>, full=True)` — everything in one call.
+2. (Cheaper) `get_business_hq(business_id=<biz_id>)` for just the core dashboard, then add `include_personas` / `include_products` / `include_intents` / `include_actions` flags as needed.
+
+What to do with the response: Lead with `health_scores` (5 core scores: brand_confidence, crawl_coverage, ai_readiness, buyer_clarity, trust_score) and `priority_actions` — those tell the user what's wrong and what to fix. `recent_audits` and `recommendations` for activity context. `top_competitors` and `displacement` for competitive context. `agentic_readiness` if the user is asking specifically about AI-agent visibility.
+
+### get_competitive_comparison — strengths/weaknesses vs competitors (Pro)
+
+When to use it: Mid-conversation, the user asks "how do we stack up against X." Pulls existing competitive analysis without running new prompts.
+
+Recipe:
+1. `get_competitive_comparison(business_id=<biz_id>)`.
+
+What to do with the response: `competitors` (named competitor entities), `strengths` (top 5-10 wins), `weaknesses` (top 5-10 gaps), `market_intelligence` (supporting observations). Lead with weaknesses if the user is looking for what to fix; lead with strengths if they're pitching/positioning.
+
+### get_semantic_health — AI-readability diagnostics (Pro)
+
+When to use it: The user wants to know what to fix to be more discoverable to AI engines. Returns structured diagnostics rather than free-text recommendations.
+
+Recipe:
+1. `get_semantic_health(business_id=<biz_id>)`.
+
+What to do with the response: `entity_grounding`, `schema_coverage`, `faq_coverage`, `claim_evidence_coverage` are coverage diagnostics — surface the lowest-coverage area first as the priority fix. `trust_signals` is a list of finding+confidence entries.
+
+### buyer_fit_query — ad-hoc fit simulation (Pro)
+
+When to use it: "Would AI recommend us for X" probes — testing positioning before committing to a full audit, or evaluating a new buyer profile. Faster and cheaper than a full audit; doesn't update the business record.
+
+Recipe:
+1. `buyer_fit_query(buyer="<profile or query>", business_id=<biz_id>, limit=5)`. Add `constraints=[{...}]` to narrow.
+
+What to do with the response: `recommendations` is the ordered fit list — top entries are the strongest matches. Echo the `buyer` field back to the user so they know what was scored. If recommendations look weak, suggest a full audit with a template tuned for this buyer's queries.
+
+### export_audit — share the report outside MCP (Scale)
+
+When to use it: The user wants to forward, attach, or archive the audit as a PDF.
+
+Recipe:
+1. `export_audit(job_id=<completed_audit_job_id>)`. Add `provider="openai"|"gemini"|"perplexity"` for a per-provider view.
+
+What to do with the response: `url` is a presigned download link with a 1-hour TTL. Surface it with `expires_at` so the user knows to grab it promptly. `filename` is the suggested save name.
+
+## Compound recipes
+
+### Weekly visibility report
+
+When to use it: The user asks for a status update on AI search performance, or sets up a weekly check-in.
+
+1. `get_analytics_dashboard(business_id=<biz_id>)` — KPI trends + benchmarks in one shot.
+2. `list_audits(business_id=<biz_id>, limit=5)` — find the two most recent completed audits on the same `named_audit_id`.
+3. `compare_audits(audit_id=<latest>, baseline_id=<prior>)` — week-over-week delta.
+
+Compose into a markdown report ready to forward:
+- **Headline:** top KPI movement from `compare_audits.changes`.
+- **Trend section:** 1-2 sentences from `kpi_trends` (direction + magnitude per KPI).
+- **Regressions:** top 3 from `compare_audits.questions_comparison` where score fell.
+- **Wins:** top 2 from `compare_audits.questions_comparison` where score rose.
+- **Benchmarks:** where the business sits vs. historical from `benchmarks`.
+
+Don't dump raw JSON — the report is for a human stakeholder.
+
+### Cold-start business intel
+
+When to use it: The user asks "what does Cited know about this business" — no audit yet, or the existing data is stale.
+
+1. `get_business_hq(business_id=<biz_id>, full=True)` — comprehensive snapshot.
+2. **Decision point:** if `crawl_freshness.last_crawled_at` is missing or > 30 days old, OR `health_scores.crawl_coverage` is below ~30, the data is stale. Call `crawl_business(business_id=<biz_id>)`, save the `job_id`, then `get_job_status(job_id=<id>)` until status is `completed` (1-3 min).
+3. After the crawl finishes, `get_business_facts(business_id=<biz_id>)` for the populated fact graph.
+
+Surface: identity + the 5 health scores + populated facts (locations, products, summary). If you triggered a fresh crawl, mention that the data is now current.
+
+### Ad-hoc buyer-fit probe
+
+When to use it: The user asks "would AI recommend us if someone searched for X" or wants to test product positioning before running a full audit.
+
+1. `buyer_fit_query(buyer="<phrasing>", business_id=<biz_id>, limit=5)`.
+2. Inspect the top recommendation entry. If the response includes a numeric score field, use it; otherwise judge by the ordering and the recommendation metadata.
+3. **Decision:**
+   - **Strong fit** (top entry clearly dominant, high score if present): the business is well-positioned for this buyer; surface the matching strengths.
+   - **Mixed** (recommendations present but no clear winner): there's coverage but gaps; surface what's matching and what's missing.
+   - **Weak fit** (low scores, generic recommendations): suggest running `start_audit` with a template tuned for this buyer's queries to get a deeper diagnosis.
+
+Surface the top 2-3 recommendations and your verdict, not the raw recommendations list.
+
+## Cross-references
+
+- **Standard pipeline:** `cited:business-setup` → `cited:geo-audit` → `cited:geo-recommend`.
+- **Conversation status check:** `cited:status`.

--- a/packages/mcp/src/cited_mcp/tools/agent.py
+++ b/packages/mcp/src/cited_mcp/tools/agent.py
@@ -30,6 +30,14 @@ async def get_business_facts(
 ) -> Any:
     """Get structured business facts — key data points extracted from crawl and audit data.
 
+    Returns ``name``, ``summary``, ``locations``, ``products``, ``facts``
+    plus source metadata.
+
+    When to call: the user asks "what does Cited know about [business]" or
+    you need structured intel without running a fresh audit. Cheap, no
+    plan-budget impact. If ``summary`` is null and ``facts`` is empty the
+    fact graph is thin — recommend ``crawl_business`` to populate.
+
     Args:
         ctx: MCP context
         business_id: Business ID (uses default if omitted)
@@ -58,6 +66,11 @@ async def get_business_claims(
     business_id: str | None = None,
 ) -> Any:
     """Get verifiable claims about a business that can be fact-checked.
+
+    When to call: auditing brand truth-in-advertising, or surfacing claims
+    that need stronger evidence before they appear in AI summaries —
+    typically when the user is prepping a product page, press kit, or
+    landing page review.
 
     Args:
         ctx: MCP context
@@ -88,6 +101,13 @@ async def get_competitive_comparison(
 ) -> Any:
     """Get competitive comparison — how the business stacks up against competitors.
 
+    Returns ``competitors``, ``strengths``, ``weaknesses``, and
+    ``market_intelligence`` from the existing competitive analysis.
+
+    When to call: mid-conversation, the user asks "how do we stack up
+    against X" or wants positioning context. Doesn't run new prompts —
+    pulls from data already collected.
+
     Args:
         ctx: MCP context
         business_id: Business ID (uses default if omitted)
@@ -116,6 +136,13 @@ async def get_semantic_health(
     business_id: str | None = None,
 ) -> Any:
     """Get semantic readiness signals for AI understanding of business content.
+
+    Returns ``entity_grounding``, ``schema_coverage``, ``faq_coverage``,
+    ``claim_evidence_coverage``, and ``trust_signals``.
+
+    When to call: the user asks what to fix to be more discoverable to AI
+    engines. Returns structured diagnostics rather than free-text advice
+    — surface the lowest-coverage area first as the priority fix.
 
     Args:
         ctx: MCP context
@@ -151,6 +178,12 @@ async def buyer_fit_query(
 
     Returns ordered ``recommendations`` (product/fit matches) plus echoed
     request fields and source attribution metadata.
+
+    When to call: ad-hoc "would AI recommend us for X" probes — testing
+    positioning before committing to a full audit, or evaluating a new
+    buyer profile. Faster and cheaper than a full audit; doesn't update the
+    business record. If recommendations look weak, suggest a full audit
+    with a template tuned for this buyer's queries.
 
     Args:
         ctx: MCP context

--- a/packages/mcp/src/cited_mcp/tools/analytics.py
+++ b/packages/mcp/src/cited_mcp/tools/analytics.py
@@ -30,6 +30,10 @@ async def get_analytics_trends(
 ) -> Any:
     """Get KPI trends over time for a business — citation rates, visibility scores, and more.
 
+    When to call: you only need the KPI time-series — for a chart, a custom
+    trend computation, or a tight summary. Cheaper than get_analytics_dashboard
+    if you don't need question performance, benchmarks, or citation trends.
+
     Args:
         ctx: MCP context
         business_id: Business ID (uses default if omitted)
@@ -63,6 +67,11 @@ async def get_analytics_dashboard(
     and domain_benchmarks in a single payload — the same data backing the
     web Analytics page.
 
+    When to call: the user asks for an overview of AI search performance —
+    KPIs, trends, top/declining questions, citation patterns, benchmarks —
+    in one shot. Reach for get_analytics_trends instead if you only need
+    the time-series.
+
     Args:
         ctx: MCP context
         business_id: Business ID (uses default if omitted)
@@ -94,6 +103,11 @@ async def compare_audits(
     baseline_id: str,
 ) -> Any:
     """Compare two audits and return per-question changes plus aggregate deltas.
+
+    When to call: the user asks "what changed since the last audit" / "are
+    we improving" / "show me the week-over-week delta." Compute the diff
+    here instead of summarizing two audit reports back to back. Doesn't run
+    a new audit — cheap and idempotent.
 
     Use ``list_audits`` to find a prior completed audit on the same template
     and pass its job_id as ``baseline_id``.

--- a/packages/mcp/src/cited_mcp/tools/audit.py
+++ b/packages/mcp/src/cited_mcp/tools/audit.py
@@ -314,6 +314,9 @@ async def export_audit(
     ``expires_at``, ``expires_in_seconds``, ``filename``, and ``object_name``.
     Default URL TTL is 1 hour — surface ``expires_at`` to the user when sharing.
 
+    When to call: the user wants to forward, attach, or archive the audit
+    as a PDF (sharing with a stakeholder, saving for records, etc.).
+
     Args:
         ctx: MCP context
         job_id: The completed audit job ID

--- a/packages/mcp/src/cited_mcp/tools/hq.py
+++ b/packages/mcp/src/cited_mcp/tools/hq.py
@@ -38,6 +38,12 @@ async def get_business_hq(
     Returns health scores, and optionally personas, products, buyer intents, and priority actions.
     Use full=True to get everything in one call.
 
+    When to call: the user wants a one-shot snapshot of an account —
+    health scores, recent audits, recommendations, competitive position,
+    top action items. Reach for ``full=True`` when summarizing an account
+    holistically; use the targeted ``include_*`` flags when you only need
+    a few sections.
+
     Args:
         ctx: MCP context
         business_id: Business ID (uses default if omitted)

--- a/packages/mcp/src/cited_mcp/tools/job.py
+++ b/packages/mcp/src/cited_mcp/tools/job.py
@@ -86,6 +86,12 @@ async def cancel_job(
 ) -> Any:
     """Cancel a running job.
 
+    When to call: a get_*_status check shows a job has been "running" far
+    longer than expected (audits typically 2-4 min, recommendations 1-2 min,
+    solutions 30-60s) OR the user realizes the job was started against the
+    wrong template/business. Cancelling stops further plan-budget consumption.
+    Idempotent — safe to retry.
+
     Args:
         ctx: MCP context
         job_id: The job ID to cancel


### PR DESCRIPTION
## Summary

Surfaces eleven under-utilized MCP tools so agents reach for them under the right user prompts. The tool surface roughly doubled in the last two weeks; the skill / docs surface didn't keep up. This closes that gap.

## What's in this PR

### New skill — `cited-plugins/skills/explore/SKILL.md`

One section per tool family with the same tight three-part shape per the brief:

1. **When to use it** — the agentic job, not the docstring.
2. **Minimum viable recipe** — 2-3 calls, concrete IDs.
3. **What to surface from the response** — which fields matter, in what order.

Tool families covered (eleven total):
- `compare_audits`, `cancel_job`, `export_audit`
- `get_analytics_dashboard`, `get_analytics_trends`
- `get_business_facts`, `get_business_claims`, `get_business_hq`
- `get_competitive_comparison`, `get_semantic_health`
- `buyer_fit_query`

Three compound recipes at the end stitch tools together:
- **Weekly visibility report** — `get_analytics_dashboard` + `list_audits` + `compare_audits` → markdown report ready to forward.
- **Cold-start business intel** — `get_business_hq(full=True)` → `crawl_business` if data is stale → `get_business_facts` for the populated graph.
- **Ad-hoc buyer-fit probe** — `buyer_fit_query` → fit verdict + recommend whether a full audit is worth running.

Style mirrors `cited:status` — direct imperative, no hedging — since skills are read by agents under context pressure.

### `cited:status` cross-ref + prior whats_new edit

- One-line addition at the bottom pointing at `cited:explore` for ad-hoc tool exploration beyond the standard audit flow.
- Folds in the prior `whats_new` primary-path edit (treats `whats_new` as the primary signal when `ping` fingerprint differs, with structured-error and `tool_unavailable` fallbacks explicitly enumerated). That edit was sitting uncommitted in the working tree from the original four-PR stale-cache plan turn.

### When-to-call docstring expansions

Mirrors the `crawl_business` pattern (`When to call: ...`) across the same eleven tools. Each gets a one-paragraph trigger sentence describing the agentic job surfacing the tool — without restating what the tool does. `compare_audits` and `export_audit` already had recipe-level guidance from PR #13; this adds the trigger sentence on top.

## Tests

```
$ pytest packages/mcp/tests/ tests/ -q
258 passed, 1 skipped in 4.57s

$ ruff check src/ packages/        # All checks passed!
$ mypy packages/core/src packages/mcp/src src/cited_cli/  # Success: no issues found in 75 source files
```

No behavior change — pure docs + skill addition.

## Test plan

- [ ] Reviewer reads `cited-plugins/skills/explore/SKILL.md` end-to-end and gut-checks: does each \"When to use\" describe the agentic job (not the docstring)? Are the recipes 2-3 calls max? Do the \"what to surface\" notes name real fields from the response shapes?
- [ ] Open a fresh Claude Desktop conversation with the Cited connector + the explore skill loaded, and run the three trigger prompts:
  - \"compare my last two audits for [business]\" — should produce `list_audits` → `compare_audits` without the user naming the tools.
  - \"what does Cited know about [business]\" — should produce `get_business_hq(full=True)` and (if the data is thin) `crawl_business` → `get_business_facts`.
  - \"would AI recommend us for [query]\" — should produce `buyer_fit_query` and a verdict.

## Companion change in cited

A paired one-file PR mirrors `SKILL.md` to `frontend/public/.well-known/agent-skills/explore/SKILL.md` in the cited backend repo so external agent-discovery callers see the same skill. Linking that here when it goes up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)