### PR TITLE
test: lock down the v0.5.0 MCP surface — 83 new tests + doc-count alignment

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,6 +1,6 @@
 # cited-mcp
 
-MCP server for the [Cited](https://youcited.com) Generative Engine Optimization (GEO) platform. Exposes 56 tools that let AI assistants like Claude manage businesses, run GEO audits, generate recommendations, work a prioritized action plan, verify fixes via the Validation Engine, and create solutions — all through the [Model Context Protocol](https://modelcontextprotocol.io/).
+MCP server for the [Cited](https://youcited.com) Generative Engine Optimization (GEO) platform. Exposes 73 tools that let AI assistants like Claude manage businesses, run GEO audits, generate recommendations, work a prioritized action plan, verify fixes via the Validation Engine, and create solutions — all through the [Model Context Protocol](https://modelcontextprotocol.io/).
 
 ## Install
 
@@ -231,9 +231,9 @@ Tools are gated by subscription tier. All tiers can read data; write operations 
 
 | Tier | Tools Available |
 |------|----------------|
-| **Growth** (entry) | Auth, list/get businesses, crawl, health scores, audits (start/status/result/list), all recommendation tools, action-plan reads (get_action_plan, get_quick_wins), Validation Engine reads, job status — **22 tools** |
-| **Scale** | Everything in Growth + create/update/delete businesses, create/update/delete audit templates, all solution tools, batch solutions, export audit, cancel job, action-plan writes (mark_action_done, dismiss_action, get_action_progress) — **38 tools** |
-| **Pro** | Everything in Scale + usage stats, HQ dashboard, analytics, agent API — **56 tools** |
+| **Growth** (entry) | Auth, list/get businesses, crawl, health scores, audits (start/status/result/list), all recommendation tools, action-plan reads (get_action_plan, get_quick_wins), Validation Engine reads, job status — **31 tools** |
+| **Scale** | Everything in Growth + create/update/delete businesses, create/update/delete audit templates, all solution tools, batch solutions, export audit, cancel job, action-plan writes (mark_action_done, dismiss_action, get_action_progress) — **62 tools** |
+| **Pro** | Everything in Scale + usage stats, HQ dashboard, analytics, agent API — **73 tools** |
 
 When a user calls a tool above their plan, the server returns a structured error with an upgrade link:
 

--- a/packages/mcp/SKILL.md
+++ b/packages/mcp/SKILL.md
@@ -50,9 +50,9 @@ The typical flow is: **Business Setup → Audit → Recommendations → Solution
 
 Tools are gated by subscription tier. If a tool is above the user's plan, it returns an upgrade message with a billing link.
 
-- **Growth** (entry tier): Read-only — list/get businesses, run audits, view recommendations (19 tools)
-- **Scale**: Full write access — create/update/delete, solutions, export, cancel (32 tools)
-- **Pro**: Everything + HQ dashboard, analytics, agent API (42 tools)
+- **Growth** (entry tier): Read-only — list/get businesses, run audits, view recommendations (31 tools)
+- **Scale**: Full write access — create/update/delete, solutions, export, cancel (62 tools)
+- **Pro**: Everything + HQ dashboard, analytics, agent API (73 tools)
 
 Always call `check_auth_status` first — it shows the user's plan and remaining limits.
 

--- a/packages/mcp/tests/test_auth_provider.py
+++ b/packages/mcp/tests/test_auth_provider.py
@@ -1,4 +1,5 @@
 """Tests for the CitedOAuthProvider — specifically JWT expiry handling."""
+
 from __future__ import annotations
 
 import asyncio
@@ -59,14 +60,16 @@ class TestLoadAccessToken:
     def test_rejects_expired_user_jwt(self):
         provider = _make_provider()
         now = int(time.time())
-        token = provider._encode_token({
-            "typ": "access",
-            "sub": "client-123",
-            "scopes": ["cited"],
-            "user_jwt": _make_jwt(-60),  # expired backend JWT
-            "exp": now + 3600,
-            "iat": now,
-        })
+        token = provider._encode_token(
+            {
+                "typ": "access",
+                "sub": "client-123",
+                "scopes": ["cited"],
+                "user_jwt": _make_jwt(-60),  # expired backend JWT
+                "exp": now + 3600,
+                "iat": now,
+            }
+        )
 
         result = run(provider.load_access_token(token))
         assert result is None
@@ -75,14 +78,16 @@ class TestLoadAccessToken:
         provider = _make_provider()
         valid_jwt = _make_jwt(3600)
         now = int(time.time())
-        token = provider._encode_token({
-            "typ": "access",
-            "sub": "client-123",
-            "scopes": ["cited"],
-            "user_jwt": valid_jwt,
-            "exp": now + 3600,
-            "iat": now,
-        })
+        token = provider._encode_token(
+            {
+                "typ": "access",
+                "sub": "client-123",
+                "scopes": ["cited"],
+                "user_jwt": valid_jwt,
+                "exp": now + 3600,
+                "iat": now,
+            }
+        )
 
         result = run(provider.load_access_token(token))
         assert result is not None
@@ -94,14 +99,16 @@ class TestLoadRefreshToken:
         provider = _make_provider()
         client = _make_client()
         now = int(time.time())
-        token = provider._encode_token({
-            "typ": "refresh",
-            "sub": client.client_id,
-            "scopes": ["cited"],
-            "user_jwt": _make_jwt(-60),  # expired backend JWT
-            "exp": now + 86400,
-            "iat": now,
-        })
+        token = provider._encode_token(
+            {
+                "typ": "refresh",
+                "sub": client.client_id,
+                "scopes": ["cited"],
+                "user_jwt": _make_jwt(-60),  # expired backend JWT
+                "exp": now + 86400,
+                "iat": now,
+            }
+        )
 
         result = run(provider.load_refresh_token(client, token))
         assert result is None
@@ -111,14 +118,16 @@ class TestLoadRefreshToken:
         client = _make_client()
         valid_jwt = _make_jwt(3600)
         now = int(time.time())
-        token = provider._encode_token({
-            "typ": "refresh",
-            "sub": client.client_id,
-            "scopes": ["cited"],
-            "user_jwt": valid_jwt,
-            "exp": now + 86400,
-            "iat": now,
-        })
+        token = provider._encode_token(
+            {
+                "typ": "refresh",
+                "sub": client.client_id,
+                "scopes": ["cited"],
+                "user_jwt": valid_jwt,
+                "exp": now + 86400,
+                "iat": now,
+            }
+        )
 
         result = run(provider.load_refresh_token(client, token))
         assert result is not None

--- a/packages/mcp/tests/test_plan_gating.py
+++ b/packages/mcp/tests/test_plan_gating.py
@@ -73,6 +73,79 @@ class TestIsToolAllowed:
     def test_get_usage_stats_enterprise_allowed(self):
         assert is_tool_allowed("get_usage_stats", "enterprise") is True
 
+    # ---- v0.4.0 / v0.5.0 write tools — Scale-gated.
+    # Tier misclassifications here translate to either revenue loss (giving
+    # Scale features away free) or angry-customer paging (gating something
+    # that should be free). Per-tool assertions catch both directions; the
+    # bulk count test only catches gross deletions.
+
+    # Profile competitors
+    def test_list_profile_competitors_base_allowed(self):
+        assert is_tool_allowed("list_profile_competitors", "free") is True
+
+    def test_set_profile_competitors_growth_blocked(self):
+        assert is_tool_allowed("set_profile_competitors", "growth") is False
+
+    def test_set_profile_competitors_scale_allowed(self):
+        assert is_tool_allowed("set_profile_competitors", "scale") is True
+
+    # Persona CRUD
+    def test_create_persona_growth_blocked(self):
+        assert is_tool_allowed("create_persona", "growth") is False
+
+    def test_create_persona_scale_allowed(self):
+        assert is_tool_allowed("create_persona", "scale") is True
+
+    def test_update_persona_growth_blocked(self):
+        assert is_tool_allowed("update_persona", "growth") is False
+
+    def test_update_persona_scale_allowed(self):
+        assert is_tool_allowed("update_persona", "scale") is True
+
+    def test_delete_persona_growth_blocked(self):
+        assert is_tool_allowed("delete_persona", "growth") is False
+
+    def test_delete_persona_scale_allowed(self):
+        assert is_tool_allowed("delete_persona", "scale") is True
+
+    # Product CRUD
+    def test_create_product_growth_blocked(self):
+        assert is_tool_allowed("create_product", "growth") is False
+
+    def test_create_product_scale_allowed(self):
+        assert is_tool_allowed("create_product", "scale") is True
+
+    def test_update_product_growth_blocked(self):
+        assert is_tool_allowed("update_product", "growth") is False
+
+    def test_update_product_scale_allowed(self):
+        assert is_tool_allowed("update_product", "scale") is True
+
+    def test_delete_product_growth_blocked(self):
+        assert is_tool_allowed("delete_product", "growth") is False
+
+    def test_delete_product_scale_allowed(self):
+        assert is_tool_allowed("delete_product", "scale") is True
+
+    # Buyer-intent CRUD (v0.5.0 added update + delete)
+    def test_create_buyer_intent_growth_blocked(self):
+        assert is_tool_allowed("create_buyer_intent", "growth") is False
+
+    def test_create_buyer_intent_scale_allowed(self):
+        assert is_tool_allowed("create_buyer_intent", "scale") is True
+
+    def test_update_buyer_intent_growth_blocked(self):
+        assert is_tool_allowed("update_buyer_intent", "growth") is False
+
+    def test_update_buyer_intent_scale_allowed(self):
+        assert is_tool_allowed("update_buyer_intent", "scale") is True
+
+    def test_delete_buyer_intent_growth_blocked(self):
+        assert is_tool_allowed("delete_buyer_intent", "growth") is False
+
+    def test_delete_buyer_intent_scale_allowed(self):
+        assert is_tool_allowed("delete_buyer_intent", "scale") is True
+
 
 class TestRequiredTier:
     def test_ungated_tool(self):

--- a/packages/mcp/tests/test_surface_invariants.py
+++ b/packages/mcp/tests/test_surface_invariants.py
@@ -1,0 +1,332 @@
+"""Surface-invariant tests — catch unintended changes to the MCP tool surface.
+
+These tests don't exercise tool logic. They lock down structural properties
+that should change deliberately, not accidentally:
+
+  - The set of registered tool names (snapshot)
+  - The mapping of each tool to its plan tier (snapshot)
+  - The latest changelog entry's fingerprint matches the live registry's
+    compute_tools_fingerprint() result
+  - whats_new() returns the expected diff when called with an older
+    fingerprint (verifies the changelog cursor works end-to-end)
+  - README / SKILL.md tool-count strings match the live registry size
+
+When any of these fail, the message tells you which invariant broke. Update
+the snapshot intentionally if the change is desired.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+from cited_mcp.plan_gating import required_tier_for_tool
+from cited_mcp.server import compute_tools_fingerprint, create_stdio_server
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Locations of the artifacts we lock the surface against
+# ─────────────────────────────────────────────────────────────────────────────
+
+_PKG_ROOT = Path(__file__).resolve().parent.parent  # packages/mcp/
+_CHANGELOG = _PKG_ROOT / "src" / "cited_mcp" / "tool_changelog.yaml"
+_README = _PKG_ROOT / "README.md"
+_SKILL = _PKG_ROOT / "SKILL.md"
+
+
+@pytest.fixture(scope="module")
+def server():
+    """One server instance reused across the module — server boot is the
+    expensive bit (~100ms) and these tests are read-only."""
+    return create_stdio_server()
+
+
+@pytest.fixture(scope="module")
+def registered_tool_names(server) -> set[str]:
+    return {t.name for t in server._tool_manager.list_tools()}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Surface snapshot — the canonical tool name set
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Updated for the v0.5.0 surface (PR #23). When adding or removing a tool,
+# update this set AND the changelog top entry in one commit.
+EXPECTED_TOOLS_V0_5_0: set[str] = {
+    # Auth + meta
+    "ping",
+    "check_auth_status",
+    "login",
+    "logout",
+    "get_pricing",
+    "upgrade_plan",
+    "whats_new",
+    "get_usage_stats",
+    # Businesses
+    "list_businesses",
+    "get_business",
+    "create_business",
+    "update_business",
+    "delete_business",
+    "crawl_business",
+    "get_health_scores",
+    "list_profile_competitors",
+    "set_profile_competitors",
+    # Audit templates
+    "list_audit_templates",
+    "get_audit_template",
+    "create_audit_template",
+    "update_audit_template",
+    "delete_audit_template",
+    # Audits
+    "start_audit",
+    "get_audit_status",
+    "get_audit_result",
+    "list_audits",
+    "get_audit_question_detail",
+    "export_audit",
+    # Recommendations
+    "start_recommendation",
+    "get_recommendation_status",
+    "get_recommendation_result",
+    "get_recommendation_insights",
+    "get_recommendation_insight_detail",
+    "list_recommendations",
+    "get_recommendation_check_status",
+    "validate_recommendation",
+    "get_recommendation_validation_latest",
+    # Solutions
+    "start_solution",
+    "start_solutions_batch",
+    "get_solution_status",
+    "get_solution_result",
+    "list_solutions",
+    # Jobs
+    "get_job_status",
+    "cancel_job",
+    # HQ — composite reads + persona/product/buyer-intent CRUD
+    "get_business_hq",
+    "get_agent_brief",
+    "recompute_health_scores",
+    "refresh_business_overview",
+    "list_personas",
+    "create_persona",
+    "update_persona",
+    "delete_persona",
+    "list_products",
+    "create_product",
+    "update_product",
+    "delete_product",
+    "list_buyer_intents",
+    "create_buyer_intent",
+    "update_buyer_intent",
+    "delete_buyer_intent",
+    # Analytics
+    "get_analytics_trends",
+    "get_analytics_dashboard",
+    "compare_audits",
+    # Agent API (composite-data reads)
+    "get_business_facts",
+    "get_business_claims",
+    "get_competitive_comparison",
+    "get_semantic_health",
+    "buyer_fit_query",
+    # Action plan
+    "get_action_plan",
+    "get_quick_wins",
+    "mark_action_done",
+    "dismiss_action",
+    "get_action_progress",
+}
+
+
+def test_registered_tool_names_match_snapshot(registered_tool_names):
+    """The live tool registry must match the v0.5.0 snapshot.
+
+    On accidental removal: ``missing`` will be non-empty.
+    On accidental addition (un-snapshotted tool): ``extra`` will be non-empty.
+
+    Update EXPECTED_TOOLS_V0_5_0 above when a release intentionally adds or
+    removes a tool, and bump the changelog in the same commit so whats_new()
+    surfaces the change to existing clients.
+    """
+    missing = EXPECTED_TOOLS_V0_5_0 - registered_tool_names
+    extra = registered_tool_names - EXPECTED_TOOLS_V0_5_0
+    assert missing == set(), f"Tools missing from registry: {missing}"
+    assert extra == set(), (
+        f"Tools registered without being in the snapshot: {extra}. "
+        f"Add them to EXPECTED_TOOLS_V0_5_0 and the changelog top entry."
+    )
+
+
+# Per-tool tier snapshot — catches subtle tier reclassifications that the
+# bulk counts wouldn't notice. Update this when intentionally changing a
+# tool's tier.
+EXPECTED_TIER_FOR_TOOL: dict[str, str | None] = {
+    # Scale-tier write tools (the v0.4.0 / v0.5.0 surface)
+    "create_business": "scale",
+    "delete_business": "scale",
+    "set_profile_competitors": "scale",
+    "create_persona": "scale",
+    "update_persona": "scale",
+    "delete_persona": "scale",
+    "create_product": "scale",
+    "update_product": "scale",
+    "delete_product": "scale",
+    "create_buyer_intent": "scale",
+    "update_buyer_intent": "scale",
+    "delete_buyer_intent": "scale",
+    "recompute_health_scores": "scale",
+    "refresh_business_overview": "scale",
+    # Pro-tier — billing-sensitive analytics
+    "get_usage_stats": "pro",
+    "compare_audits": "pro",
+    "get_analytics_trends": "pro",
+    "get_analytics_dashboard": "pro",
+}
+
+
+def test_per_tool_tier_assignments_stable():
+    """Lock down the tier each gated tool is mapped to. Catches accidental
+    re-classifications (e.g., a Pro tool slipping to Scale would silently
+    give it away for less revenue)."""
+    drift: dict[str, tuple[str | None, str | None]] = {}
+    for tool, expected in EXPECTED_TIER_FOR_TOOL.items():
+        actual = required_tier_for_tool(tool)
+        if actual != expected:
+            drift[tool] = (expected, actual)
+    assert drift == {}, (
+        f"Tier drift detected (expected → actual): {drift}. "
+        f"If intentional, update EXPECTED_TIER_FOR_TOOL."
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Changelog fingerprint integrity
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _load_changelog() -> dict:
+    return yaml.safe_load(_CHANGELOG.read_text())
+
+
+def test_top_changelog_entry_fingerprint_matches_live_registry(server):
+    """The newest tool_changelog.yaml entry must pin the live registry's
+    fingerprint. Drift here means either:
+      (a) someone changed the tool surface without bumping the changelog, or
+      (b) the changelog entry was pinned before the surface stabilized.
+
+    Either way it breaks ``whats_new`` for clients that cache fingerprints —
+    they'll be told they're up to date when they aren't."""
+    changelog = _load_changelog()
+    top = changelog["versions"][0]
+    live_fp = compute_tools_fingerprint(server)
+    assert top["fingerprint"] == live_fp, (
+        f"Top changelog entry ({top['version']}) has fingerprint "
+        f"{top['fingerprint']!r} but the live registry computes "
+        f"{live_fp!r}. Recompute and update the changelog entry, OR add a "
+        f"new top entry if a release is in progress."
+    )
+
+
+def test_no_changelog_entries_still_pending():
+    """No production changelog entry should ship with a ``fingerprint:
+    "PENDING"`` value. The release.sh script substitutes PENDING for the
+    live value on tag; a PENDING value on main means a release was authored
+    but never tagged.
+
+    Match only the YAML value form (``fingerprint: "PENDING"``), not the
+    word ``PENDING`` appearing in the file's instructional header comments.
+    """
+    text = _CHANGELOG.read_text()
+    pending_values = re.findall(r'fingerprint:\s*"PENDING"', text)
+    assert pending_values == [], (
+        "PENDING placeholder remains in tool_changelog.yaml. "
+        "Run scripts/release.sh to substitute or hand-pin it."
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# README / SKILL.md tool count consistency
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+_TOOL_COUNT_RE = re.compile(r"(\d{2,3})\s*(?:tools|MCP tools)\b", re.IGNORECASE)
+
+
+def _extract_documented_tool_counts(path: Path) -> list[int]:
+    """Find any 'NN tools' or 'NN MCP tools' strings in a doc — these are
+    the most common places stale counts live."""
+    if not path.exists():
+        return []
+    return [int(m) for m in _TOOL_COUNT_RE.findall(path.read_text())]
+
+
+def test_readme_tool_count_matches_registry(registered_tool_names):
+    """If README.md cites tool counts, at least one must be the live total.
+
+    Docs typically carry multiple ``NN tools`` mentions (per-tier breakdowns
+    like 31 / 62 / 73). The simplest invariant that catches release-stale
+    docs is: the live registry size must appear at least once. A README
+    that's been updated for the current release will mention the total
+    somewhere; one that's drifted won't.
+    """
+    counts = _extract_documented_tool_counts(_README)
+    if not counts:
+        pytest.skip("README has no 'NN tools' string to verify")
+    live = len(registered_tool_names)
+    assert live in counts, (
+        f"README cites tool counts {sorted(set(counts))} — none match the "
+        f"live registry size {live}. Update the README's top-line total."
+    )
+
+
+def test_skill_tool_count_matches_registry(registered_tool_names):
+    """SKILL.md is the entry-point document for MCP directories (Anthropic
+    Connectors etc.). Same rule as README: at least one mentioned count
+    must be the live total."""
+    counts = _extract_documented_tool_counts(_SKILL)
+    if not counts:
+        pytest.skip("SKILL.md has no 'NN tools' string to verify")
+    live = len(registered_tool_names)
+    assert live in counts, (
+        f"SKILL.md cites tool counts {sorted(set(counts))} — none match "
+        f"the live registry size {live}. Update SKILL.md's top-line total."
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# whats_new diff coverage — verify the changelog cursor works end-to-end
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_whats_new_returns_v0_5_0_entries_from_v0_4_0_fingerprint():
+    """A client cached at v0.4.0's fingerprint calling whats_new should see
+    v0.5.0's added/changed tools. Catches: dropped entries, version-
+    ordering bugs, fingerprint typos in the changelog."""
+    changelog = _load_changelog()
+    v0_4_0 = next((v for v in changelog["versions"] if v["version"] == "0.4.0"), None)
+    v0_5_0 = next((v for v in changelog["versions"] if v["version"] == "0.5.0"), None)
+    assert v0_4_0 is not None, "0.4.0 entry missing from changelog"
+    assert v0_5_0 is not None, "0.5.0 entry missing from changelog"
+
+    # v0.5.0 must add at minimum the buyer-intent write tools (the
+    # symmetry-completing PR) and the list_* discovery tools the agent
+    # needs before CRUD.
+    added = {t["name"] for t in v0_5_0.get("tools_added", [])}
+    changed = {t["name"] for t in v0_5_0.get("tools_changed", [])}
+    delta = added | changed
+    expected_min_additions = {
+        "list_personas",
+        "list_products",
+        "list_buyer_intents",
+        "update_buyer_intent",
+        "delete_buyer_intent",
+    }
+    missing = expected_min_additions - delta
+    assert missing == set(), (
+        f"v0.5.0 changelog entry doesn't record {missing}. whats_new() "
+        f"would silently fail to surface these to upgrading clients."
+    )

--- a/packages/mcp/tests/test_tools.py
+++ b/packages/mcp/tests/test_tools.py
@@ -129,10 +129,26 @@ from cited_mcp.tools.business import (  # noqa: E402
     get_health_scores,
     get_usage_stats,
     list_businesses,
+    list_profile_competitors,
+    set_profile_competitors,
     update_business,
 )
 from cited_mcp.tools.changelog import whats_new  # noqa: E402
-from cited_mcp.tools.hq import get_business_hq  # noqa: E402
+from cited_mcp.tools.hq import (  # noqa: E402
+    create_buyer_intent,
+    create_persona,
+    create_product,
+    delete_buyer_intent,
+    delete_persona,
+    delete_product,
+    get_business_hq,
+    list_buyer_intents,
+    list_personas,
+    list_products,
+    update_buyer_intent,
+    update_persona,
+    update_product,
+)
 from cited_mcp.tools.job import cancel_job, get_job_status  # noqa: E402
 from cited_mcp.tools.recommend import (  # noqa: E402
     get_recommendation_check_status,
@@ -259,17 +275,19 @@ class TestBusinessTools:
         client = ctx.request_context.lifespan_context.client
         client.patch.return_value = {"id": "b1"}
 
-        run(update_business(
-            ctx,
-            business_id="b1",
-            one_line_description="Tagline",
-            primary_market="local",
-            service_areas="Atlanta metro",
-            headquarters_country="US",
-            goals=["Be cited"],
-            address="123 Main St",
-            city="Atlanta",
-        ))
+        run(
+            update_business(
+                ctx,
+                business_id="b1",
+                one_line_description="Tagline",
+                primary_market="local",
+                service_areas="Atlanta metro",
+                headquarters_country="US",
+                goals=["Be cited"],
+                address="123 Main St",
+                city="Atlanta",
+            )
+        )
         payload = client.patch.call_args[1]["json"]
         assert payload == {
             "one_line_description": "Tagline",
@@ -287,16 +305,19 @@ class TestBusinessTools:
         client.post.return_value = {"id": "new-id"}
 
         from cited_mcp.tools.business import create_business as _create
-        run(_create(
-            ctx,
-            name="Acme",
-            website="https://acme.com",
-            primary_customer="Mid-market RevOps",
-            problem_solved="Manual rev-data wrangling",
-            offering_type="service",
-            primary_market="national",
-            headquarters_country="US",
-        ))
+
+        run(
+            _create(
+                ctx,
+                name="Acme",
+                website="https://acme.com",
+                primary_customer="Mid-market RevOps",
+                problem_solved="Manual rev-data wrangling",
+                offering_type="service",
+                primary_market="national",
+                headquarters_country="US",
+            )
+        )
         payload = client.post.call_args[1]["json"]
         # Required fields always present
         assert payload["name"] == "Acme"
@@ -2449,3 +2470,441 @@ class TestActionPlanTools:
         result = run(get_action_progress(ctx, business_id="b1"))
         assert result["error"] is True
         assert result["status_code"] == 500
+
+
+# ---------------------------------------------------------------------------
+# Profile competitors (business.py — v0.4.0 surface)
+# ---------------------------------------------------------------------------
+
+
+class TestProfileCompetitorsTools:
+    """Coverage for list_profile_competitors + set_profile_competitors —
+    the user-declared competitors that bypass third-party citation-only
+    filtering in audits and head-to-head comparisons."""
+
+    def test_list_profile_competitors_unauth(self, unauth_ctx):
+        result = run(list_profile_competitors(unauth_ctx, business_id="b1"))
+        assert result["error"] is True
+
+    def test_list_profile_competitors_happy_path(self, ctx):
+        client = ctx.request_context.lifespan_context.client
+        client.get.return_value = [
+            {"id": "c1", "name": "Acme", "website": "https://acme.com"},
+            {"id": "c2", "name": "Globex", "website": "https://globex.com"},
+        ]
+        result = run(list_profile_competitors(ctx, business_id="b1"))
+        # log_tool_call wraps list responses as {data: [...], _request_id: ...}
+        assert len(result["data"]) == 2
+        assert result["data"][0]["name"] == "Acme"
+        path = client.get.call_args[0][0]
+        assert "/businesses/b1/profile-competitors" in path
+
+    def test_list_profile_competitors_requires_business_id(self, ctx):
+        # No business_id, no default — must return the actionable error so
+        # the agent knows to call list_businesses first.
+        result = run(list_profile_competitors(ctx))
+        assert result["error"] is True
+        assert "business_id" in result["message"]
+
+    def test_list_profile_competitors_uses_default_business(self, ctx):
+        ctx.request_context.lifespan_context.default_business_id = "default-biz"
+        client = ctx.request_context.lifespan_context.client
+        client.get.return_value = []
+        run(list_profile_competitors(ctx))
+        path = client.get.call_args[0][0]
+        assert "/businesses/default-biz/profile-competitors" in path
+
+    def test_set_profile_competitors_unauth(self, unauth_ctx):
+        result = run(
+            set_profile_competitors(
+                unauth_ctx,
+                competitors=[{"name": "Acme", "website": "https://acme.com"}],
+                business_id="b1",
+            )
+        )
+        assert result["error"] is True
+
+    def test_set_profile_competitors_happy_path(self, ctx):
+        client = ctx.request_context.lifespan_context.client
+        client.put.return_value = [
+            {"id": "c1", "name": "Rival", "website": "https://rival.com"},
+        ]
+        result = run(
+            set_profile_competitors(
+                ctx,
+                competitors=[
+                    {"name": "Rival", "website": "https://rival.com"},
+                ],
+                business_id="b1",
+            )
+        )
+        # REPLACE semantics → returns the new state
+        # log_tool_call wraps list responses as {data: [...], _request_id: ...}
+        assert result["data"][0]["name"] == "Rival"
+        client.put.assert_called_once()
+        payload = client.put.call_args[1]["json"]
+        assert payload["competitors"][0]["name"] == "Rival"
+        path = client.put.call_args[0][0]
+        assert "/businesses/b1/profile-competitors" in path
+
+    def test_set_profile_competitors_caps_at_10(self, ctx):
+        """Max 10 competitors per business (matches backend rule)."""
+        too_many = [{"name": f"R{i}", "website": f"https://r{i}.com"} for i in range(11)]
+        result = run(set_profile_competitors(ctx, competitors=too_many, business_id="b1"))
+        assert result["error"] is True
+        assert "10" in result["message"]
+
+    def test_set_profile_competitors_rejects_non_list(self, ctx):
+        result = run(
+            set_profile_competitors(
+                ctx,
+                competitors="not-a-list",  # type: ignore[arg-type]
+                business_id="b1",
+            )
+        )
+        assert result["error"] is True
+        assert "list" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# Persona CRUD (hq.py — v0.4.0 surface)
+# ---------------------------------------------------------------------------
+
+
+class TestPersonaTools:
+    """Coverage for the persona CRUD chain: list_personas → create_persona
+    → update_persona → delete_persona. Agents need list_personas to
+    discover ids before update/delete; the update/delete paths use the
+    singular ``PERSONA`` endpoint with the persona_id."""
+
+    # ---- list_personas
+
+    def test_list_personas_unauth(self, unauth_ctx):
+        result = run(list_personas(unauth_ctx, business_id="b1"))
+        assert result["error"] is True
+
+    def test_list_personas_happy_path(self, ctx):
+        client = ctx.request_context.lifespan_context.client
+        client.get.return_value = [
+            {"id": "p1", "name": "RevOps lead", "role": "manager"},
+        ]
+        result = run(list_personas(ctx, business_id="b1"))
+        assert result["data"][0]["id"] == "p1"
+        path = client.get.call_args[0][0]
+        assert "/businesses/b1/personas" in path
+        # The plural endpoint (no persona_id segment)
+        assert not path.endswith("/p1")
+
+    def test_list_personas_requires_business_id(self, ctx):
+        result = run(list_personas(ctx))
+        assert result["error"] is True
+        assert "business_id" in result["message"]
+
+    # ---- create_persona
+
+    def test_create_persona_unauth(self, unauth_ctx):
+        result = run(create_persona(unauth_ctx, name="X", business_id="b1"))
+        assert result["error"] is True
+
+    def test_create_persona_happy_path(self, ctx):
+        client = ctx.request_context.lifespan_context.client
+        client.post.return_value = {"id": "p1", "name": "RevOps lead"}
+        result = run(
+            create_persona(
+                ctx,
+                name="RevOps lead",
+                description="Owns rev-data tooling",
+                role="manager",
+                goals=["Close more deals"],
+                pain_points=["Manual data wrangling"],
+                business_id="b1",
+            )
+        )
+        assert result["id"] == "p1"
+        client.post.assert_called_once()
+        payload = client.post.call_args[1]["json"]
+        assert payload["name"] == "RevOps lead"
+        assert payload["role"] == "manager"
+        assert payload["goals"] == ["Close more deals"]
+        assert payload["pain_points"] == ["Manual data wrangling"]
+        path = client.post.call_args[0][0]
+        assert "/businesses/b1/personas" in path
+
+    def test_create_persona_omits_unset_optional_fields(self, ctx):
+        """Optional fields with None default must NOT appear in the payload."""
+        client = ctx.request_context.lifespan_context.client
+        client.post.return_value = {"id": "p1"}
+        run(create_persona(ctx, name="X", business_id="b1"))
+        payload = client.post.call_args[1]["json"]
+        assert payload == {"name": "X"}
+
+    # ---- update_persona
+
+    def test_update_persona_unauth(self, unauth_ctx):
+        result = run(update_persona(unauth_ctx, persona_id="p1", name="X", business_id="b1"))
+        assert result["error"] is True
+
+    def test_update_persona_happy_path_uses_patch(self, ctx):
+        client = ctx.request_context.lifespan_context.client
+        client.patch.return_value = {"id": "p1", "name": "Updated"}
+        result = run(update_persona(ctx, persona_id="p1", name="Updated", business_id="b1"))
+        assert result["name"] == "Updated"
+        # Mirror PATCH semantics — partial update, not PUT
+        client.patch.assert_called_once()
+        path = client.patch.call_args[0][0]
+        assert "/businesses/b1/personas/p1" in path
+        payload = client.patch.call_args[1]["json"]
+        assert payload == {"name": "Updated"}
+
+    def test_update_persona_requires_at_least_one_field(self, ctx):
+        """Calling update with no fields is meaningless and must error."""
+        result = run(update_persona(ctx, persona_id="p1", business_id="b1"))
+        assert result["error"] is True
+        assert "field" in result["message"].lower()
+
+    # ---- delete_persona
+
+    def test_delete_persona_unauth(self, unauth_ctx):
+        result = run(delete_persona(unauth_ctx, persona_id="p1", business_id="b1"))
+        assert result["error"] is True
+
+    def test_delete_persona_happy_path(self, ctx):
+        client = ctx.request_context.lifespan_context.client
+        client.delete.return_value = None
+        result = run(delete_persona(ctx, persona_id="p1", business_id="b1"))
+        assert result["success"] is True
+        assert result["persona_id"] == "p1"
+        client.delete.assert_called_once()
+        path = client.delete.call_args[0][0]
+        assert "/businesses/b1/personas/p1" in path
+
+
+# ---------------------------------------------------------------------------
+# Product CRUD (hq.py — v0.4.0 surface)
+# ---------------------------------------------------------------------------
+
+
+class TestProductTools:
+    """Coverage for the product CRUD chain. Same pattern as personas —
+    list/create/update/delete with the singular PRODUCT endpoint."""
+
+    # ---- list_products
+
+    def test_list_products_unauth(self, unauth_ctx):
+        result = run(list_products(unauth_ctx, business_id="b1"))
+        assert result["error"] is True
+
+    def test_list_products_happy_path(self, ctx):
+        client = ctx.request_context.lifespan_context.client
+        client.get.return_value = [{"id": "pr1", "name": "Widget"}]
+        result = run(list_products(ctx, business_id="b1"))
+        assert result["data"][0]["id"] == "pr1"
+        path = client.get.call_args[0][0]
+        assert "/businesses/b1/products" in path
+
+    # ---- create_product
+
+    def test_create_product_unauth(self, unauth_ctx):
+        result = run(create_product(unauth_ctx, name="X", business_id="b1"))
+        assert result["error"] is True
+
+    def test_create_product_happy_path(self, ctx):
+        client = ctx.request_context.lifespan_context.client
+        client.post.return_value = {"id": "pr1", "name": "Widget"}
+        result = run(
+            create_product(
+                ctx,
+                name="Widget",
+                description="A widget",
+                url="https://widget.com",
+                category="hardware",
+                business_id="b1",
+            )
+        )
+        assert result["id"] == "pr1"
+        payload = client.post.call_args[1]["json"]
+        assert payload["name"] == "Widget"
+        assert payload["url"] == "https://widget.com"
+        assert payload["category"] == "hardware"
+        path = client.post.call_args[0][0]
+        assert "/businesses/b1/products" in path
+
+    # ---- update_product
+
+    def test_update_product_unauth(self, unauth_ctx):
+        result = run(update_product(unauth_ctx, product_id="pr1", name="X", business_id="b1"))
+        assert result["error"] is True
+
+    def test_update_product_happy_path_uses_patch(self, ctx):
+        client = ctx.request_context.lifespan_context.client
+        client.patch.return_value = {"id": "pr1", "name": "Renamed"}
+        result = run(update_product(ctx, product_id="pr1", name="Renamed", business_id="b1"))
+        assert result["name"] == "Renamed"
+        client.patch.assert_called_once()
+        path = client.patch.call_args[0][0]
+        assert "/businesses/b1/products/pr1" in path
+
+    def test_update_product_requires_at_least_one_field(self, ctx):
+        result = run(update_product(ctx, product_id="pr1", business_id="b1"))
+        assert result["error"] is True
+
+    # ---- delete_product
+
+    def test_delete_product_unauth(self, unauth_ctx):
+        result = run(delete_product(unauth_ctx, product_id="pr1", business_id="b1"))
+        assert result["error"] is True
+
+    def test_delete_product_happy_path(self, ctx):
+        client = ctx.request_context.lifespan_context.client
+        client.delete.return_value = None
+        result = run(delete_product(ctx, product_id="pr1", business_id="b1"))
+        assert result["success"] is True
+        assert result["product_id"] == "pr1"
+        path = client.delete.call_args[0][0]
+        assert "/businesses/b1/products/pr1" in path
+
+
+# ---------------------------------------------------------------------------
+# Buyer-intent CRUD (hq.py — v0.4.0 list/create + v0.5.0 update/delete)
+# ---------------------------------------------------------------------------
+
+
+class TestBuyerIntentTools:
+    """Coverage for the buyer-intent CRUD chain. update_buyer_intent and
+    delete_buyer_intent are the v0.5.0 additions that fill the symmetry
+    gap with personas/products. The backend routes are PATCH/DELETE
+    ``/businesses/{id}/buyer-intents/{intent_id}``."""
+
+    # ---- list_buyer_intents
+
+    def test_list_buyer_intents_unauth(self, unauth_ctx):
+        result = run(list_buyer_intents(unauth_ctx, business_id="b1"))
+        assert result["error"] is True
+
+    def test_list_buyer_intents_happy_path(self, ctx):
+        client = ctx.request_context.lifespan_context.client
+        client.get.return_value = [{"id": "i1", "intent": "evaluating CRM"}]
+        result = run(list_buyer_intents(ctx, business_id="b1"))
+        assert result["data"][0]["id"] == "i1"
+        path = client.get.call_args[0][0]
+        assert "/businesses/b1/buyer-intents" in path
+
+    # ---- create_buyer_intent
+
+    def test_create_buyer_intent_unauth(self, unauth_ctx):
+        result = run(create_buyer_intent(unauth_ctx, intent="X", business_id="b1"))
+        assert result["error"] is True
+
+    def test_create_buyer_intent_happy_path(self, ctx):
+        client = ctx.request_context.lifespan_context.client
+        client.post.return_value = {"id": "i1", "intent": "evaluating CRM"}
+        result = run(
+            create_buyer_intent(
+                ctx,
+                intent="evaluating CRM",
+                description="Mid-market shopping CRMs",
+                persona_ids=["p1", "p2"],
+                product_ids=["pr1"],
+                business_id="b1",
+            )
+        )
+        assert result["id"] == "i1"
+        payload = client.post.call_args[1]["json"]
+        assert payload["intent"] == "evaluating CRM"
+        assert payload["persona_ids"] == ["p1", "p2"]
+        assert payload["product_ids"] == ["pr1"]
+        path = client.post.call_args[0][0]
+        assert "/businesses/b1/buyer-intents" in path
+
+    # ---- update_buyer_intent (v0.5.0)
+
+    def test_update_buyer_intent_unauth(self, unauth_ctx):
+        result = run(
+            update_buyer_intent(unauth_ctx, intent_id="i1", question="X", business_id="b1")
+        )
+        assert result["error"] is True
+
+    def test_update_buyer_intent_happy_path_uses_patch(self, ctx):
+        """v0.5.0: full PATCH against singular /buyer-intents/{intent_id}."""
+        client = ctx.request_context.lifespan_context.client
+        client.patch.return_value = {"id": "i1", "question": "Renamed?"}
+        result = run(
+            update_buyer_intent(
+                ctx,
+                intent_id="i1",
+                question="Renamed?",
+                priority="high",
+                is_answered=True,
+                business_id="b1",
+            )
+        )
+        assert result["question"] == "Renamed?"
+        client.patch.assert_called_once()
+        path = client.patch.call_args[0][0]
+        assert "/businesses/b1/buyer-intents/i1" in path
+        payload = client.patch.call_args[1]["json"]
+        assert payload["question"] == "Renamed?"
+        assert payload["priority"] == "high"
+        assert payload["is_answered"] is True
+
+    def test_update_buyer_intent_omits_unset_fields(self, ctx):
+        """Partial-update semantics: only provided fields in the payload."""
+        client = ctx.request_context.lifespan_context.client
+        client.patch.return_value = {"id": "i1"}
+        run(update_buyer_intent(ctx, intent_id="i1", priority="low", business_id="b1"))
+        payload = client.patch.call_args[1]["json"]
+        assert payload == {"priority": "low"}
+
+    def test_update_buyer_intent_requires_at_least_one_field(self, ctx):
+        result = run(update_buyer_intent(ctx, intent_id="i1", business_id="b1"))
+        assert result["error"] is True
+        assert "field" in result["message"].lower()
+
+    # ---- delete_buyer_intent (v0.5.0)
+
+    def test_delete_buyer_intent_unauth(self, unauth_ctx):
+        result = run(delete_buyer_intent(unauth_ctx, intent_id="i1", business_id="b1"))
+        assert result["error"] is True
+
+    def test_delete_buyer_intent_happy_path(self, ctx):
+        client = ctx.request_context.lifespan_context.client
+        client.delete.return_value = None
+        result = run(delete_buyer_intent(ctx, intent_id="i1", business_id="b1"))
+        assert result["success"] is True
+        assert result["intent_id"] == "i1"
+        path = client.delete.call_args[0][0]
+        assert "/businesses/b1/buyer-intents/i1" in path
+
+
+# ---------------------------------------------------------------------------
+# update_business / create_business — additional error-path coverage
+# (the happy paths already exist; this fills the gaps around HTTP method
+# correctness and the 422/404 hint pattern that test_mcp_tools.py uses
+# for create_business but not for update/delete.)
+# ---------------------------------------------------------------------------
+
+
+class TestBusinessWriteErrorHandling:
+    def test_update_business_404_returns_structured_error(self, ctx):
+        client = ctx.request_context.lifespan_context.client
+        client.patch.side_effect = CitedAPIError(404, "Business not found")
+        result = run(update_business(ctx, business_id="missing", name="X"))
+        assert result["error"] is True
+        assert result["status_code"] == 404
+
+    def test_update_business_422_returns_structured_error(self, ctx):
+        client = ctx.request_context.lifespan_context.client
+        client.patch.side_effect = CitedAPIError(422, "validation failed")
+        result = run(update_business(ctx, business_id="b1", industry="not-real"))
+        assert result["error"] is True
+        assert result["status_code"] == 422
+
+    def test_delete_business_403_indicates_plan_limit(self, ctx):
+        """Single-business plans return 403 on delete — verify the tool
+        surfaces a structured error (the chat agent will format an upgrade
+        prompt from this)."""
+        client = ctx.request_context.lifespan_context.client
+        client.delete.side_effect = CitedAPIError(403, "plan limit")
+        result = run(delete_business(ctx, business_id="b1"))
+        assert result["error"] is True
+        assert result["status_code"] == 403

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,9 @@ from cited_cli.app import app
 
 
 def pytest_addoption(parser):
-    parser.addoption("--live", action="store_true", default=False, help="Run live integration tests")
+    parser.addoption(
+        "--live", action="store_true", default=False, help="Run live integration tests"
+    )
 
 
 def pytest_configure(config):

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import json
-
 import httpx
 import pytest
 import respx

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -207,24 +207,31 @@ def test_register_password_flow(runner, cli_app, tmp_path, monkeypatch):
 
     respx.post("https://api.youcited.com/auth/cli-register").mock(
         return_value=httpx.Response(
-            201, json={"message": "Verification email sent. Check your inbox to complete registration."}
+            201,
+            json={"message": "Verification email sent. Check your inbox to complete registration."},
         )
     )
     respx.post("https://api.youcited.com/auth/cli-verify-email").mock(
-        return_value=httpx.Response(
-            200, json={"token": "register-jwt-token", "user": _FAKE_USER}
-        )
+        return_value=httpx.Response(200, json={"token": "register-jwt-token", "user": _FAKE_USER})
     )
 
-    fake_verify_url = "https://app.youcited.com/complete-registration?token=fake-verification-token-abc123xyz"
+    fake_verify_url = (
+        "https://app.youcited.com/complete-registration?token=fake-verification-token-abc123xyz"
+    )
 
     result = runner.invoke(
         cli_app,
         [
-            "--env", "prod", "auth", "register",
-            "--email", "new@example.com",
-            "--name", "Test User",
-            "--password", "Secret1234",
+            "--env",
+            "prod",
+            "auth",
+            "register",
+            "--email",
+            "new@example.com",
+            "--name",
+            "Test User",
+            "--password",
+            "Secret1234",
         ],
         input=f"{fake_verify_url}\n",
     )
@@ -243,24 +250,30 @@ def test_top_level_register(runner, cli_app, tmp_path, monkeypatch):
 
     respx.post("https://api.youcited.com/auth/cli-register").mock(
         return_value=httpx.Response(
-            201, json={"message": "Verification email sent. Check your inbox to complete registration."}
+            201,
+            json={"message": "Verification email sent. Check your inbox to complete registration."},
         )
     )
     respx.post("https://api.youcited.com/auth/cli-verify-email").mock(
-        return_value=httpx.Response(
-            200, json={"token": "top-register-jwt", "user": _FAKE_USER}
-        )
+        return_value=httpx.Response(200, json={"token": "top-register-jwt", "user": _FAKE_USER})
     )
 
-    fake_verify_url = "https://app.youcited.com/complete-registration?token=fake-verification-token-abc123xyz"
+    fake_verify_url = (
+        "https://app.youcited.com/complete-registration?token=fake-verification-token-abc123xyz"
+    )
 
     result = runner.invoke(
         cli_app,
         [
-            "--env", "prod", "register",
-            "--email", "new@example.com",
-            "--name", "Test User",
-            "--password", "Secret1234",
+            "--env",
+            "prod",
+            "register",
+            "--email",
+            "new@example.com",
+            "--name",
+            "Test User",
+            "--password",
+            "Secret1234",
         ],
         input=f"{fake_verify_url}\n",
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import json
 
-import pytest
-
 
 def test_config_set_and_get(runner, cli_app, tmp_path, monkeypatch):
     config_dir = tmp_path / ".cited"

--- a/tests/test_feature_parity.py
+++ b/tests/test_feature_parity.py
@@ -5,49 +5,50 @@ preventing feature drift between the two interfaces. When adding a new
 feature, add it to BOTH the CLI and MCP, then update the exceptions
 below if the gap is intentional.
 """
+
 from __future__ import annotations
 
 import pytest
 
-
 # Intentional gaps — features that only make sense in one interface.
 # Each entry must have a comment explaining WHY it's CLI-only or MCP-only.
 CLI_ONLY = {
-    "auth token",       # Raw JWT export — only useful for CLI scripting/piping
-    "auth register",    # Account creation — one-time flow, not suited for MCP
-    "register",         # Top-level alias for auth register
-    "config set",       # Local config management — no equivalent in MCP
-    "config get",       # Local config management
-    "config show",      # Local config management
+    "auth token",  # Raw JWT export — only useful for CLI scripting/piping
+    "auth register",  # Account creation — one-time flow, not suited for MCP
+    "register",  # Top-level alias for auth register
+    "config set",  # Local config management — no equivalent in MCP
+    "config get",  # Local config management
+    "config show",  # Local config management
     "config environments",  # Local config management
-    "mcp serve",        # Starts the MCP server itself — meta, not a tool
-    "job watch",        # Live Rich progress bar — interactive terminal only
-    "version",          # CLI version display — not meaningful for MCP
+    "mcp serve",  # Starts the MCP server itself — meta, not a tool
+    "job watch",  # Live Rich progress bar — interactive terminal only
+    "version",  # CLI version display — not meaningful for MCP
 }
 
 MCP_ONLY = {
-    "ping",                     # Lightweight readiness check — CLI users run `cited status` instead
-    "get_pricing",              # Agent payment discovery — CLI users visit billing page
-    "upgrade_plan",             # Agent plan upgrade — CLI users visit billing page
-    "whats_new",                # Tool-surface diff for stale MCP-client caches — CLI doesn't have a tool cache
-    "get_usage_stats",          # Aggregated stats — CLI uses auth status + business list
-    "get_job_status",           # MCP probes types; CLI uses job watch (live polling)
+    "ping",  # Lightweight readiness check — CLI users run `cited status` instead
+    "get_pricing",  # Agent payment discovery — CLI users visit billing page
+    "upgrade_plan",  # Agent plan upgrade — CLI users visit billing page
+    "whats_new",  # Tool-surface diff for stale MCP-client caches — CLI doesn't have a tool cache
+    "get_usage_stats",  # Aggregated stats — CLI uses auth status + business list
+    "get_job_status",  # MCP probes types; CLI uses job watch (live polling)
     "get_audit_question_detail",  # Drill-down from summary — CLI uses audit result (full)
     "get_recommendation_insight_detail",  # Drill-down from summary — CLI uses recommend full
-    "start_solutions_batch",    # Bulk operation — CLI users call solution start in a loop
+    "start_solutions_batch",  # Bulk operation — CLI users call solution start in a loop
     # Action plan tools — agent/conversational checklist UX, no CLI equivalent yet
-    "get_action_plan",          # Conversational ranked checklist — agents only
-    "get_quick_wins",           # Filtered checklist for "what should I do now?" — agents only
-    "mark_action_done",         # Stateful progress mark — agents update checklist via chat
-    "dismiss_action",           # Stateful progress mark — agents dismiss via chat
-    "get_action_progress",      # Progress summary — surfaced inline by the agent
+    "get_action_plan",  # Conversational ranked checklist — agents only
+    "get_quick_wins",  # Filtered checklist for "what should I do now?" — agents only
+    "mark_action_done",  # Stateful progress mark — agents update checklist via chat
+    "dismiss_action",  # Stateful progress mark — agents dismiss via chat
+    "get_action_progress",  # Progress summary — surfaced inline by the agent
 }
 
 
 def _get_cli_commands() -> set[str]:
     """Extract all CLI commands as 'group subcommand' strings."""
-    from cited_cli.app import app
     import typer
+
+    from cited_cli.app import app
 
     commands: set[str] = set()
 
@@ -208,6 +209,4 @@ def test_mapped_mcp_tools_actually_exist():
     for cli_cmd, mcp_tool in _CLI_TO_MCP.items():
         tools = [mcp_tool] if isinstance(mcp_tool, str) else mcp_tool
         for t in tools:
-            assert t in mcp_tools, (
-                f"CLI '{cli_cmd}' maps to MCP tool '{t}' which is not registered"
-            )
+            assert t in mcp_tools, f"CLI '{cli_cmd}' maps to MCP tool '{t}' which is not registered"

--- a/tests/test_live_pipeline.py
+++ b/tests/test_live_pipeline.py
@@ -84,8 +84,8 @@ def test_full_live_pipeline():
     """Full customer journey against the live dev API."""
     _ensure_mcp_initialized()
 
+    from cited_mcp.tools.audit import create_audit_template, get_audit_result, start_audit
     from cited_mcp.tools.auth import check_auth_status
-    from cited_mcp.tools.audit import create_audit_template, start_audit, get_audit_result
     from cited_mcp.tools.business import (
         create_business,
         delete_business,
@@ -129,7 +129,9 @@ def test_full_live_pipeline():
 
         # 3. Get health scores (baseline, may be empty)
         scores = _run(get_health_scores(ctx, business_id))
-        assert not isinstance(scores, dict) or not scores.get("error"), f"Health scores failed: {scores}"
+        assert not isinstance(scores, dict) or not scores.get("error"), (
+            f"Health scores failed: {scores}"
+        )
         print(f"  Health scores: {type(scores).__name__}")
 
         # 4. Create audit template
@@ -165,7 +167,7 @@ def test_full_live_pipeline():
         audit_result = _run(get_audit_result(ctx, audit_job_id))
         assert audit_result is not None
         assert not (isinstance(audit_result, dict) and audit_result.get("error"))
-        print(f"  Audit result: OK")
+        print("  Audit result: OK")
 
         # 8. Start recommendation
         rec = _run(start_recommendation(ctx, audit_job_id))
@@ -191,11 +193,7 @@ def test_full_live_pipeline():
 
         # 11. Start solution from first question insight (if available)
         if qi:
-            sol = _run(
-                start_solution(
-                    ctx, rec_job_id, qi[0]["source_type"], qi[0]["source_id"]
-                )
-            )
+            sol = _run(start_solution(ctx, rec_job_id, qi[0]["source_type"], qi[0]["source_id"]))
             assert "job_id" in sol, f"Solution start failed: {sol}"
             sol_job_id = sol["job_id"]
             print(f"  Solution job: {sol_job_id}")
@@ -209,7 +207,7 @@ def test_full_live_pipeline():
             sol_result = _run(get_solution_result(ctx, sol_job_id))
             assert sol_result is not None
             assert not (isinstance(sol_result, dict) and sol_result.get("error"))
-            print(f"  Solution result: OK")
+            print("  Solution result: OK")
 
         print("  Pipeline complete!")
 

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -22,12 +22,15 @@ def _mcp_available():
         pytest.skip("mcp not installed")
     # Ensure the MCP server instance is created so tools can register
     import cited_mcp.server as server_mod
+
     if server_mod.mcp is None:
         server_mod.create_stdio_server()
     # Pre-seed tier cache so plan gating doesn't make unexpected /auth/me calls
     import hashlib
     import time
+
     from cited_mcp.tools._helpers import _tier_cache
+
     cache_key = hashlib.sha256(b"test-token").hexdigest()[:16]
     _tier_cache[cache_key] = ("pro", time.monotonic() + 3600)
     yield
@@ -115,7 +118,11 @@ def test_create_business():
     )
     cited_ctx = _make_cited_ctx()
     ctx = _make_mcp_ctx(cited_ctx)
-    result = _run(create_business(ctx, "NewCo", "https://newco.com", "A new company for testing", "technology"))
+    result = _run(
+        create_business(
+            ctx, "NewCo", "https://newco.com", "A new company for testing", "technology"
+        )
+    )
     assert result["id"] == "b2"
     cited_ctx.client.close()
 
@@ -189,18 +196,26 @@ def test_get_recommendation_insights():
     from cited_mcp.tools.recommend import get_recommendation_insights
 
     respx.get(f"{DEV_API}/recommendations/rj1/result").mock(
-        return_value=httpx.Response(200, json={
-            "question_insights": [
-                {"question_id": "q1", "question_text": "Q?", "risk_level": "high", "coverage_score": 0.3}
-            ],
-            "head_to_head_comparisons": [
-                {"competitor_domain": "comp.com", "overall_winner": "business"}
-            ],
-            "strengthening_tips": [
-                {"category": "llms_txt", "title": "Create llms.txt", "priority": "high"}
-            ],
-            "priority_actions": [],
-        })
+        return_value=httpx.Response(
+            200,
+            json={
+                "question_insights": [
+                    {
+                        "question_id": "q1",
+                        "question_text": "Q?",
+                        "risk_level": "high",
+                        "coverage_score": 0.3,
+                    }
+                ],
+                "head_to_head_comparisons": [
+                    {"competitor_domain": "comp.com", "overall_winner": "business"}
+                ],
+                "strengthening_tips": [
+                    {"category": "llms_txt", "title": "Create llms.txt", "priority": "high"}
+                ],
+                "priority_actions": [],
+            },
+        )
     )
     cited_ctx = _make_cited_ctx()
     ctx = _make_mcp_ctx(cited_ctx)
@@ -306,8 +321,8 @@ def test_logout():
 def test_login_force_clears_token():
     from unittest.mock import MagicMock, patch
 
-    from cited_mcp.tools.auth import login
     import cited_mcp.tools.auth as auth_mod
+    from cited_mcp.tools.auth import login
 
     # Ensure no stale pending login from other tests
     auth_mod._pending_login = None
@@ -352,9 +367,15 @@ def test_api_error_403_includes_hint():
     )
     cited_ctx = _make_cited_ctx()
     ctx = _make_mcp_ctx(cited_ctx)
-    result = _run(create_business(
-        ctx, "Test", "https://test.com", "A test business description", "technology",
-    ))
+    result = _run(
+        create_business(
+            ctx,
+            "Test",
+            "https://test.com",
+            "A test business description",
+            "technology",
+        )
+    )
     assert result["error"] is True
     assert result["status_code"] == 403
     assert "hint" in result
@@ -372,9 +393,7 @@ def test_api_error_422_includes_hint():
     )
     cited_ctx = _make_cited_ctx()
     ctx = _make_mcp_ctx(cited_ctx)
-    result = _run(
-        create_business(ctx, "Test", "https://fake.example.com", "Short", "technology")
-    )
+    result = _run(create_business(ctx, "Test", "https://fake.example.com", "Short", "technology"))
     assert result["error"] is True
     assert result["status_code"] == 422
     assert "hint" in result

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
 import json
-import sys
-from io import StringIO
 
-from cited_cli.output.formatter import OutputContext, print_error, print_result, print_success
+from cited_cli.output.formatter import OutputContext, print_result, print_success
 
 
 def test_print_result_json(capsys):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -26,6 +26,7 @@ watch_job is monkeypatched to return an instant "completed" dict — this keeps
 tests fast and avoids Rich's Live renderer interacting with the CliRunner's
 StringIO stdout.
 """
+
 from __future__ import annotations
 
 import json
@@ -42,13 +43,13 @@ from cited_cli.app import app
 # Pipeline-wide ID constants
 # These UUIDs are used as the canonical IDs throughout all tests in this file.
 # ─────────────────────────────────────────────────────────────────────────────
-BUSINESS_ID       = "b1a2c3d4-e5f6-7890-abcd-ef1234567890"
-TEMPLATE_ID       = "t1a2c3d4-e5f6-7890-abcd-ef1234567891"
-AUDIT_JOB_ID      = "a1a2c3d4-e5f6-7890-abcd-ef1234567892"
-RECOMMEND_JOB_ID  = "r1a2c3d4-e5f6-7890-abcd-ef1234567893"
-SOLUTION_JOB_ID   = "s1a2c3d4-e5f6-7890-abcd-ef1234567894"
-CRAWL_JOB_ID      = "c1a2c3d4-e5f6-7890-abcd-ef1234567895"
-QI_SOURCE_ID      = "qi-abc123def456"       # question_insight source
+BUSINESS_ID = "b1a2c3d4-e5f6-7890-abcd-ef1234567890"
+TEMPLATE_ID = "t1a2c3d4-e5f6-7890-abcd-ef1234567891"
+AUDIT_JOB_ID = "a1a2c3d4-e5f6-7890-abcd-ef1234567892"
+RECOMMEND_JOB_ID = "r1a2c3d4-e5f6-7890-abcd-ef1234567893"
+SOLUTION_JOB_ID = "s1a2c3d4-e5f6-7890-abcd-ef1234567894"
+CRAWL_JOB_ID = "c1a2c3d4-e5f6-7890-abcd-ef1234567895"
+QI_SOURCE_ID = "qi-abc123def456"  # question_insight source
 HTH_COMPETITOR_DOMAIN = "competitorx.com"  # head_to_head competitor_domain
 
 # Dev API base URL (matches cited_cli/config/constants.py ENVIRONMENTS["dev"])
@@ -209,13 +210,24 @@ MOCK_SOLUTION_STARTED = {
 MOCK_TEMPLATE_LIST = [MOCK_TEMPLATE]
 
 # Reusable list of audits (for history endpoint)
-MOCK_AUDIT_LIST = [{"job_id": AUDIT_JOB_ID, "business_name": "Acme GEO Corp", "status": "completed", "created_at": "2026-03-17T12:02:00Z"}]
+MOCK_AUDIT_LIST = [
+    {
+        "job_id": AUDIT_JOB_ID,
+        "business_name": "Acme GEO Corp",
+        "status": "completed",
+        "created_at": "2026-03-17T12:02:00Z",
+    }
+]
 
 # Reusable list of recommendations (for history endpoint)
-MOCK_RECOMMEND_LIST = [{"job_id": RECOMMEND_JOB_ID, "status": "completed", "created_at": "2026-03-17T12:05:00Z"}]
+MOCK_RECOMMEND_LIST = [
+    {"job_id": RECOMMEND_JOB_ID, "status": "completed", "created_at": "2026-03-17T12:05:00Z"}
+]
 
 # Reusable list of solutions (for history endpoint)
-MOCK_SOLUTION_LIST = [{"job_id": SOLUTION_JOB_ID, "status": "completed", "created_at": "2026-03-17T12:10:00Z"}]
+MOCK_SOLUTION_LIST = [
+    {"job_id": SOLUTION_JOB_ID, "status": "completed", "created_at": "2026-03-17T12:10:00Z"}
+]
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -238,13 +250,13 @@ def _setup_logged_in(tmp_path, monkeypatch) -> None:
     """
     config_dir = tmp_path / ".cited"
     config_file = config_dir / "config.toml"
-    creds_file  = config_dir / "credentials.json"
+    creds_file = config_dir / "credentials.json"
 
-    monkeypatch.setattr("cited_core.config.constants.CONFIG_DIR",      config_dir)
-    monkeypatch.setattr("cited_core.config.constants.CONFIG_FILE",     config_file)
+    monkeypatch.setattr("cited_core.config.constants.CONFIG_DIR", config_dir)
+    monkeypatch.setattr("cited_core.config.constants.CONFIG_FILE", config_file)
     monkeypatch.setattr("cited_core.config.constants.CREDENTIALS_FILE", creds_file)
-    monkeypatch.setattr("cited_core.auth.store.CONFIG_DIR",             config_dir)
-    monkeypatch.setattr("cited_core.auth.store.CREDENTIALS_FILE",       creds_file)
+    monkeypatch.setattr("cited_core.auth.store.CONFIG_DIR", config_dir)
+    monkeypatch.setattr("cited_core.auth.store.CREDENTIALS_FILE", creds_file)
     # Disable keyring so credentials go to the plain JSON file
     monkeypatch.setattr("cited_core.auth.store.TokenStore._has_keyring", lambda self: False)
 
@@ -255,18 +267,17 @@ def _setup_logged_in(tmp_path, monkeypatch) -> None:
 
 def _mock_watch_job_completed(job_id: str):
     """Return a monkeypatch target that resolves watch_job instantly as completed."""
+
     def _instant_complete(client, status_path, console, poll_interval=2.0):
         return {"status": "completed", "job_id": job_id, "progress": 1.0}
+
     return _instant_complete
 
 
 def _invoke(runner, cli_app, args: list[str]) -> Any:
     """Run a CLI command and assert it succeeded, returning the parsed JSON."""
     result = runner.invoke(cli_app, args)
-    assert result.exit_code == 0, (
-        f"Command failed: cited {' '.join(args)}\n"
-        f"Output: {result.output}"
-    )
+    assert result.exit_code == 0, f"Command failed: cited {' '.join(args)}\nOutput: {result.output}"
     return result
 
 
@@ -274,21 +285,32 @@ def _invoke(runner, cli_app, args: list[str]) -> Any:
 # Step 1 — Business Creation
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 @respx.mock
 def test_business_create_returns_id(runner, cli_app, tmp_path, monkeypatch):
     """business create outputs JSON with an 'id' field in --json mode."""
     _setup_logged_in(tmp_path, monkeypatch)
-    respx.post(f"{DEV_API}/businesses").mock(
-        return_value=httpx.Response(201, json=MOCK_BUSINESS)
-    )
+    respx.post(f"{DEV_API}/businesses").mock(return_value=httpx.Response(201, json=MOCK_BUSINESS))
 
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "--json", "business", "create",
-        "--name", "Acme GEO Corp",
-        "--website", "https://acme.example.com",
-        "--description", "Acme makes AI-powered tools for enterprise teams with great GEO presence.",
-        "--industry", "SaaS",
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "business",
+            "create",
+            "--name",
+            "Acme GEO Corp",
+            "--website",
+            "https://acme.example.com",
+            "--description",
+            "Acme makes AI-powered tools for enterprise teams with great GEO presence.",
+            "--industry",
+            "SaaS",
+        ],
+    )
 
     data = json.loads(result.output)
     assert data["id"] == BUSINESS_ID
@@ -300,16 +322,24 @@ def test_business_create_returns_id(runner, cli_app, tmp_path, monkeypatch):
 def test_business_create_human_output(runner, cli_app, tmp_path, monkeypatch):
     """business create renders a key-value panel in human mode."""
     _setup_logged_in(tmp_path, monkeypatch)
-    respx.post(f"{DEV_API}/businesses").mock(
-        return_value=httpx.Response(201, json=MOCK_BUSINESS)
-    )
+    respx.post(f"{DEV_API}/businesses").mock(return_value=httpx.Response(201, json=MOCK_BUSINESS))
 
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "business", "create",
-        "--name", "Acme GEO Corp",
-        "--website", "https://acme.example.com",
-        "--description", "Acme makes AI-powered tools for enterprise teams with great GEO presence.",
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "business",
+            "create",
+            "--name",
+            "Acme GEO Corp",
+            "--website",
+            "https://acme.example.com",
+            "--description",
+            "Acme makes AI-powered tools for enterprise teams with great GEO presence.",
+        ],
+    )
 
     assert "Acme GEO Corp" in result.output
     assert "acme.example.com" in result.output
@@ -323,12 +353,21 @@ def test_business_create_api_error(runner, cli_app, tmp_path, monkeypatch):
         return_value=httpx.Response(422, json={"detail": "website is not a valid URL"})
     )
 
-    result = runner.invoke(cli_app, [
-        "--env", "dev", "business", "create",
-        "--name", "Bad Business",
-        "--website", "not-a-url",
-        "--description", "This should fail because the website is invalid per the backend.",
-    ])
+    result = runner.invoke(
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "business",
+            "create",
+            "--name",
+            "Bad Business",
+            "--website",
+            "not-a-url",
+            "--description",
+            "This should fail because the website is invalid per the backend.",
+        ],
+    )
 
     assert result.exit_code != 0
 
@@ -340,12 +379,21 @@ def test_business_create_requires_auth(runner, cli_app, tmp_path, monkeypatch):
     creds_file = tmp_path / ".cited" / "credentials.json"
     creds_file.write_text(json.dumps({}))
 
-    result = runner.invoke(cli_app, [
-        "--env", "dev", "business", "create",
-        "--name", "X",
-        "--website", "https://x.com",
-        "--description", "A valid description that is long enough for the check.",
-    ])
+    result = runner.invoke(
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "business",
+            "create",
+            "--name",
+            "X",
+            "--website",
+            "https://x.com",
+            "--description",
+            "A valid description that is long enough for the check.",
+        ],
+    )
 
     assert result.exit_code != 0
     assert "Not logged in" in result.output
@@ -355,22 +403,35 @@ def test_business_create_requires_auth(runner, cli_app, tmp_path, monkeypatch):
 # Step 2 — Audit Template CRUD
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 @respx.mock
 def test_template_create_returns_id(runner, cli_app, tmp_path, monkeypatch):
     """audit template create returns JSON with an 'id' field usable as next step input."""
     _setup_logged_in(tmp_path, monkeypatch)
-    respx.post(f"{DEV_API}/named-audits").mock(
-        return_value=httpx.Response(201, json=MOCK_TEMPLATE)
-    )
+    respx.post(f"{DEV_API}/named-audits").mock(return_value=httpx.Response(201, json=MOCK_TEMPLATE))
 
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "--json", "audit", "template", "create",
-        "--name", "Q4 GEO Audit",
-        "--business", BUSINESS_ID,
-        "--description", "Checks citation presence across key GEO keywords",
-        "--question", "Are you cited when people ask about AI tools?",
-        "--question", "Does your product appear for enterprise GEO searches?",
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "audit",
+            "template",
+            "create",
+            "--name",
+            "Q4 GEO Audit",
+            "--business",
+            BUSINESS_ID,
+            "--description",
+            "Checks citation presence across key GEO keywords",
+            "--question",
+            "Are you cited when people ask about AI tools?",
+            "--question",
+            "Does your product appear for enterprise GEO searches?",
+        ],
+    )
 
     data = json.loads(result.output)
     assert data["id"] == TEMPLATE_ID
@@ -382,16 +443,25 @@ def test_template_create_returns_id(runner, cli_app, tmp_path, monkeypatch):
 def test_template_create_human_output_shows_run_hint(runner, cli_app, tmp_path, monkeypatch):
     """audit template create (human mode) prints a hint for the next command."""
     _setup_logged_in(tmp_path, monkeypatch)
-    respx.post(f"{DEV_API}/named-audits").mock(
-        return_value=httpx.Response(201, json=MOCK_TEMPLATE)
-    )
+    respx.post(f"{DEV_API}/named-audits").mock(return_value=httpx.Response(201, json=MOCK_TEMPLATE))
 
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "audit", "template", "create",
-        "--name", "Q4 GEO Audit",
-        "--business", BUSINESS_ID,
-        "--question", "Are you cited when people ask about AI tools?",
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "audit",
+            "template",
+            "create",
+            "--name",
+            "Q4 GEO Audit",
+            "--business",
+            BUSINESS_ID,
+            "--question",
+            "Are you cited when people ask about AI tools?",
+        ],
+    )
 
     assert "cited audit start" in result.output
     assert TEMPLATE_ID in result.output
@@ -424,10 +494,19 @@ def test_template_list_filtered_by_business(runner, cli_app, tmp_path, monkeypat
 
     respx.get(f"{DEV_API}/named-audits").mock(side_effect=_capture)
 
-    _invoke(runner, cli_app, [
-        "--env", "dev", "audit", "template", "list",
-        "--business", BUSINESS_ID,
-    ])
+    _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "audit",
+            "template",
+            "list",
+            "--business",
+            BUSINESS_ID,
+        ],
+    )
 
     assert captured_params.get("business_id") == BUSINESS_ID
 
@@ -461,12 +540,25 @@ def test_template_update_replaces_questions(runner, cli_app, tmp_path, monkeypat
 
     respx.put(f"{DEV_API}/named-audits/{TEMPLATE_ID}").mock(side_effect=_capture)
 
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "--json", "audit", "template", "update", TEMPLATE_ID,
-        "--question", "Are we cited for AI safety research?",
-        "--question", "Do enterprise buyers find us via AI assistants?",
-        "--question", "Are we mentioned in responsible AI discussions?",
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "audit",
+            "template",
+            "update",
+            TEMPLATE_ID,
+            "--question",
+            "Are we cited for AI safety research?",
+            "--question",
+            "Do enterprise buyers find us via AI assistants?",
+            "--question",
+            "Are we mentioned in responsible AI discussions?",
+        ],
+    )
 
     data = json.loads(result.output)
     assert data["id"] == TEMPLATE_ID
@@ -488,10 +580,21 @@ def test_template_update_name_only(runner, cli_app, tmp_path, monkeypatch):
 
     respx.put(f"{DEV_API}/named-audits/{TEMPLATE_ID}").mock(side_effect=_capture)
 
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "--json", "audit", "template", "update", TEMPLATE_ID,
-        "--name", "Q4 GEO Audit Revised",
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "audit",
+            "template",
+            "update",
+            TEMPLATE_ID,
+            "--name",
+            "Q4 GEO Audit Revised",
+        ],
+    )
 
     data = json.loads(result.output)
     assert data["name"] == "Q4 GEO Audit Revised"
@@ -507,10 +610,19 @@ def test_template_update_human_shows_questions(runner, cli_app, tmp_path, monkey
         return_value=httpx.Response(200, json=MOCK_TEMPLATE_UPDATED)
     )
 
-    result = runner.invoke(cli_app, [
-        "--env", "dev", "audit", "template", "update", TEMPLATE_ID,
-        "--question", "Are we cited for AI safety research?",
-    ])
+    result = runner.invoke(
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "audit",
+            "template",
+            "update",
+            TEMPLATE_ID,
+            "--question",
+            "Are we cited for AI safety research?",
+        ],
+    )
 
     assert result.exit_code == 0
     assert "Template Updated" in result.output
@@ -522,9 +634,17 @@ def test_template_update_no_args_exits_with_error(runner, cli_app, tmp_path, mon
     """audit template update with no flags exits with validation error."""
     _setup_logged_in(tmp_path, monkeypatch)
 
-    result = runner.invoke(cli_app, [
-        "--env", "dev", "audit", "template", "update", TEMPLATE_ID,
-    ])
+    result = runner.invoke(
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "audit",
+            "template",
+            "update",
+            TEMPLATE_ID,
+        ],
+    )
 
     assert result.exit_code == 4  # VALIDATION_ERROR
 
@@ -533,13 +653,21 @@ def test_template_update_no_args_exits_with_error(runner, cli_app, tmp_path, mon
 def test_template_delete_with_flag_skips_prompt(runner, cli_app, tmp_path, monkeypatch):
     """audit template delete --yes deletes without confirmation prompt."""
     _setup_logged_in(tmp_path, monkeypatch)
-    respx.delete(f"{DEV_API}/named-audits/{TEMPLATE_ID}").mock(
-        return_value=httpx.Response(204)
-    )
+    respx.delete(f"{DEV_API}/named-audits/{TEMPLATE_ID}").mock(return_value=httpx.Response(204))
 
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "audit", "template", "delete", TEMPLATE_ID, "--yes",
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "audit",
+            "template",
+            "delete",
+            TEMPLATE_ID,
+            "--yes",
+        ],
+    )
 
     assert result.exit_code == 0
 
@@ -548,9 +676,7 @@ def test_template_delete_with_flag_skips_prompt(runner, cli_app, tmp_path, monke
 def test_template_delete_prompts_without_flag(runner, cli_app, tmp_path, monkeypatch):
     """audit template delete without --yes prompts for confirmation."""
     _setup_logged_in(tmp_path, monkeypatch)
-    respx.delete(f"{DEV_API}/named-audits/{TEMPLATE_ID}").mock(
-        return_value=httpx.Response(204)
-    )
+    respx.delete(f"{DEV_API}/named-audits/{TEMPLATE_ID}").mock(return_value=httpx.Response(204))
 
     # Answer "n" → Abort
     result = runner.invoke(
@@ -565,6 +691,7 @@ def test_template_delete_prompts_without_flag(runner, cli_app, tmp_path, monkeyp
 # Step 3 — Audit Start
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 @respx.mock
 def test_audit_start_returns_job_id(runner, cli_app, tmp_path, monkeypatch):
     """audit start returns JSON with a job_id field."""
@@ -573,9 +700,18 @@ def test_audit_start_returns_job_id(runner, cli_app, tmp_path, monkeypatch):
         return_value=httpx.Response(202, json=MOCK_AUDIT_STARTED)
     )
 
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "--json", "audit", "start", TEMPLATE_ID,
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "audit",
+            "start",
+            TEMPLATE_ID,
+        ],
+    )
 
     data = json.loads(result.output)
     assert data["job_id"] == AUDIT_JOB_ID
@@ -595,10 +731,19 @@ def test_audit_start_sends_named_audit_id(runner, cli_app, tmp_path, monkeypatch
 
     respx.post(f"{DEV_API}/audit/start").mock(side_effect=_capture)
 
-    _invoke(runner, cli_app, [
-        "--env", "dev", "audit", "start", TEMPLATE_ID,
-        "--business", BUSINESS_ID,
-    ])
+    _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "audit",
+            "start",
+            TEMPLATE_ID,
+            "--business",
+            BUSINESS_ID,
+        ],
+    )
 
     assert captured_body.get("named_audit_id") == TEMPLATE_ID
     assert captured_body.get("business_id") == BUSINESS_ID
@@ -619,11 +764,21 @@ def test_audit_start_with_providers(runner, cli_app, tmp_path, monkeypatch):
 
     respx.post(f"{DEV_API}/audit/start").mock(side_effect=_capture)
 
-    _invoke(runner, cli_app, [
-        "--env", "dev", "audit", "start", TEMPLATE_ID,
-        "--provider", "openai",
-        "--provider", "perplexity",
-    ])
+    _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "audit",
+            "start",
+            TEMPLATE_ID,
+            "--provider",
+            "openai",
+            "--provider",
+            "perplexity",
+        ],
+    )
 
     assert set(captured_body.get("providers", [])) == {"openai", "perplexity"}
 
@@ -646,6 +801,7 @@ def test_audit_start_human_output_shows_watch_hint(runner, cli_app, tmp_path, mo
 # Step 4 — Job Watch (Audit)
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 @respx.mock
 def test_job_watch_audit_completes(runner, cli_app, tmp_path, monkeypatch):
     """job watch polls the audit status endpoint and prints 'completed' on success."""
@@ -655,9 +811,19 @@ def test_job_watch_audit_completes(runner, cli_app, tmp_path, monkeypatch):
         _mock_watch_job_completed(AUDIT_JOB_ID),
     )
 
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "job", "watch", AUDIT_JOB_ID, "--type", "audit",
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "job",
+            "watch",
+            AUDIT_JOB_ID,
+            "--type",
+            "audit",
+        ],
+    )
 
     assert "completed" in result.output.lower()
 
@@ -695,9 +861,18 @@ def test_job_watch_failed_job_exits_nonzero(runner, cli_app, tmp_path, monkeypat
         },
     )
 
-    result = runner.invoke(cli_app, [
-        "--env", "dev", "job", "watch", AUDIT_JOB_ID, "--type", "audit",
-    ])
+    result = runner.invoke(
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "job",
+            "watch",
+            AUDIT_JOB_ID,
+            "--type",
+            "audit",
+        ],
+    )
 
     assert result.exit_code != 0
     assert "failed" in result.output.lower() or "Provider timeout" in result.output
@@ -707,6 +882,7 @@ def test_job_watch_failed_job_exits_nonzero(runner, cli_app, tmp_path, monkeypat
 # Step 5 — Audit Result
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 @respx.mock
 def test_audit_result_json_output(runner, cli_app, tmp_path, monkeypatch):
     """audit result returns JSON with question-level citation data."""
@@ -715,9 +891,18 @@ def test_audit_result_json_output(runner, cli_app, tmp_path, monkeypatch):
         return_value=httpx.Response(200, json=MOCK_AUDIT_RESULT)
     )
 
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "--json", "audit", "result", AUDIT_JOB_ID,
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "audit",
+            "result",
+            AUDIT_JOB_ID,
+        ],
+    )
 
     data = json.loads(result.output)
     assert data["job_id"] == AUDIT_JOB_ID
@@ -746,6 +931,7 @@ def test_audit_list_renders_table(runner, cli_app, tmp_path, monkeypatch):
 # Step 6 — Business Crawl
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 @respx.mock
 def test_business_crawl_starts_successfully(runner, cli_app, tmp_path, monkeypatch):
     """business crawl posts to the crawl endpoint and shows 'Crawl Started'."""
@@ -768,9 +954,18 @@ def test_business_crawl_json_output(runner, cli_app, tmp_path, monkeypatch):
         return_value=httpx.Response(202, json=MOCK_CRAWL_STARTED)
     )
 
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "--json", "business", "crawl", BUSINESS_ID,
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "business",
+            "crawl",
+            BUSINESS_ID,
+        ],
+    )
 
     data = json.loads(result.output)
     assert data["business_id"] == BUSINESS_ID
@@ -781,6 +976,7 @@ def test_business_crawl_json_output(runner, cli_app, tmp_path, monkeypatch):
 # ─────────────────────────────────────────────────────────────────────────────
 # Step 7 — Business Health (view crawl results)
 # ─────────────────────────────────────────────────────────────────────────────
+
 
 @respx.mock
 def test_business_health_renders_score_bars(runner, cli_app, tmp_path, monkeypatch):
@@ -806,9 +1002,18 @@ def test_business_health_json_output(runner, cli_app, tmp_path, monkeypatch):
         return_value=httpx.Response(200, json=MOCK_HEALTH_SCORES)
     )
 
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "--json", "business", "health", BUSINESS_ID,
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "business",
+            "health",
+            BUSINESS_ID,
+        ],
+    )
 
     data = json.loads(result.output)
     scores = data.get("scores", {})
@@ -820,6 +1025,7 @@ def test_business_health_json_output(runner, cli_app, tmp_path, monkeypatch):
 # Step 8 — Recommend Start
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 @respx.mock
 def test_recommend_start_returns_job_id(runner, cli_app, tmp_path, monkeypatch):
     """recommend start returns JSON with a job_id to feed into job watch."""
@@ -828,9 +1034,18 @@ def test_recommend_start_returns_job_id(runner, cli_app, tmp_path, monkeypatch):
         return_value=httpx.Response(202, json=MOCK_RECOMMEND_STARTED)
     )
 
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "--json", "recommend", "start", AUDIT_JOB_ID,
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "recommend",
+            "start",
+            AUDIT_JOB_ID,
+        ],
+    )
 
     data = json.loads(result.output)
     assert data["job_id"] == RECOMMEND_JOB_ID
@@ -873,6 +1088,7 @@ def test_recommend_start_human_output_shows_watch_hint(runner, cli_app, tmp_path
 # Step 9 — Job Watch (Recommendations)
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 @respx.mock
 def test_job_watch_recommend_completes(runner, cli_app, tmp_path, monkeypatch):
     """job watch on a recommendations job exits zero and prints completion."""
@@ -882,10 +1098,19 @@ def test_job_watch_recommend_completes(runner, cli_app, tmp_path, monkeypatch):
         _mock_watch_job_completed(RECOMMEND_JOB_ID),
     )
 
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "job", "watch", RECOMMEND_JOB_ID,
-        "--type", "recommendations",
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "job",
+            "watch",
+            RECOMMEND_JOB_ID,
+            "--type",
+            "recommendations",
+        ],
+    )
 
     assert "completed" in result.output.lower()
 
@@ -918,6 +1143,7 @@ def test_job_watch_auto_detects_recommend_type(runner, cli_app, tmp_path, monkey
 # Step 10 — Recommend Insights
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 @respx.mock
 def test_recommend_insights_table_contains_source_ids(runner, cli_app, tmp_path, monkeypatch):
     """recommend insights renders a table with Type, Source ID, and Description columns."""
@@ -926,9 +1152,17 @@ def test_recommend_insights_table_contains_source_ids(runner, cli_app, tmp_path,
         return_value=httpx.Response(200, json=MOCK_RECOMMEND_RESULT)
     )
 
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "recommend", "insights", RECOMMEND_JOB_ID,
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "recommend",
+            "insights",
+            RECOMMEND_JOB_ID,
+        ],
+    )
 
     assert "Available Insights" in result.output
     # question_id is the source_id for question_insights
@@ -951,9 +1185,17 @@ def test_recommend_insights_shows_solution_command_hint(runner, cli_app, tmp_pat
         return_value=httpx.Response(200, json=MOCK_RECOMMEND_RESULT)
     )
 
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "recommend", "insights", RECOMMEND_JOB_ID,
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "recommend",
+            "insights",
+            RECOMMEND_JOB_ID,
+        ],
+    )
 
     assert "cited solution start" in result.output
     assert RECOMMEND_JOB_ID in result.output
@@ -967,9 +1209,18 @@ def test_recommend_insights_json_output(runner, cli_app, tmp_path, monkeypatch):
         return_value=httpx.Response(200, json=MOCK_RECOMMEND_RESULT)
     )
 
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "--json", "recommend", "insights", RECOMMEND_JOB_ID,
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "recommend",
+            "insights",
+            RECOMMEND_JOB_ID,
+        ],
+    )
 
     data = json.loads(result.output)
     # Real API uses question_id (not id) for question_insights
@@ -993,9 +1244,17 @@ def test_recommend_insights_field_name_regression(runner, cli_app, tmp_path, mon
         return_value=httpx.Response(200, json=MOCK_RECOMMEND_RESULT)
     )
 
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "recommend", "insights", RECOMMEND_JOB_ID,
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "recommend",
+            "insights",
+            RECOMMEND_JOB_ID,
+        ],
+    )
 
     # question_insight row: source_id is question_id value
     assert QI_SOURCE_ID in result.output
@@ -1017,9 +1276,18 @@ def test_recommend_list_renders_table(runner, cli_app, tmp_path, monkeypatch):
         return_value=httpx.Response(200, json=MOCK_RECOMMEND_LIST)
     )
 
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "recommend", "list", "--audit", AUDIT_JOB_ID,
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "recommend",
+            "list",
+            "--audit",
+            AUDIT_JOB_ID,
+        ],
+    )
 
     assert "Recommendations" in result.output
     assert "completed" in result.output
@@ -1029,6 +1297,7 @@ def test_recommend_list_renders_table(runner, cli_app, tmp_path, monkeypatch):
 # Step 11 — Solution Start
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 @respx.mock
 def test_solution_start_returns_job_id(runner, cli_app, tmp_path, monkeypatch):
     """solution start returns JSON with a job_id."""
@@ -1037,11 +1306,22 @@ def test_solution_start_returns_job_id(runner, cli_app, tmp_path, monkeypatch):
         return_value=httpx.Response(202, json=MOCK_SOLUTION_STARTED)
     )
 
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "--json", "solution", "start", RECOMMEND_JOB_ID,
-        "--type", "question_insight",
-        "--source", QI_SOURCE_ID,
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "solution",
+            "start",
+            RECOMMEND_JOB_ID,
+            "--type",
+            "question_insight",
+            "--source",
+            QI_SOURCE_ID,
+        ],
+    )
 
     data = json.loads(result.output)
     assert data["job_id"] == SOLUTION_JOB_ID
@@ -1069,11 +1349,21 @@ def test_solution_start_uses_solution_request_endpoint(runner, cli_app, tmp_path
     respx.post(f"{DEV_API}/solutions/request").mock(side_effect=_capture_request)
     respx.post(f"{DEV_API}/solutions/create").mock(side_effect=_deprecated_called_handler)
 
-    _invoke(runner, cli_app, [
-        "--env", "dev", "solution", "start", RECOMMEND_JOB_ID,
-        "--type", "question_insight",
-        "--source", QI_SOURCE_ID,
-    ])
+    _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "solution",
+            "start",
+            RECOMMEND_JOB_ID,
+            "--type",
+            "question_insight",
+            "--source",
+            QI_SOURCE_ID,
+        ],
+    )
 
     # Correct endpoint was called with the right payload
     assert captured_body.get("recommendation_job_id") == RECOMMEND_JOB_ID
@@ -1093,11 +1383,21 @@ def test_solution_start_shows_web_nudge(runner, cli_app, tmp_path, monkeypatch):
         return_value=httpx.Response(202, json=MOCK_SOLUTION_STARTED)
     )
 
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "solution", "start", RECOMMEND_JOB_ID,
-        "--type", "question_insight",
-        "--source", QI_SOURCE_ID,
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "solution",
+            "start",
+            RECOMMEND_JOB_ID,
+            "--type",
+            "question_insight",
+            "--source",
+            QI_SOURCE_ID,
+        ],
+    )
 
     # Web nudge must include the solution job ID and point to the dev web origin
     assert SOLUTION_JOB_ID in result.output
@@ -1112,11 +1412,21 @@ def test_solution_start_shows_watch_hint(runner, cli_app, tmp_path, monkeypatch)
         return_value=httpx.Response(202, json=MOCK_SOLUTION_STARTED)
     )
 
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "solution", "start", RECOMMEND_JOB_ID,
-        "--type", "question_insight",
-        "--source", QI_SOURCE_ID,
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "solution",
+            "start",
+            RECOMMEND_JOB_ID,
+            "--type",
+            "question_insight",
+            "--source",
+            QI_SOURCE_ID,
+        ],
+    )
 
     assert "cited job watch" in result.output
 
@@ -1126,10 +1436,17 @@ def test_solution_start_requires_type_and_source(runner, cli_app, tmp_path, monk
     """solution start exits with a usage error when --type or --source is missing."""
     _setup_logged_in(tmp_path, monkeypatch)
 
-    result = runner.invoke(cli_app, [
-        "--env", "dev", "solution", "start", RECOMMEND_JOB_ID,
-        # Missing --type and --source
-    ])
+    result = runner.invoke(
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "solution",
+            "start",
+            RECOMMEND_JOB_ID,
+            # Missing --type and --source
+        ],
+    )
 
     assert result.exit_code != 0
 
@@ -1156,6 +1473,7 @@ def test_solution_list_renders_table(runner, cli_app, tmp_path, monkeypatch):
 #   BUSINESS_ID=$(cited --env dev --json business create ...)
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 @respx.mock
 def test_full_pipeline(runner, cli_app, tmp_path, monkeypatch):
     """
@@ -1180,12 +1498,8 @@ def test_full_pipeline(runner, cli_app, tmp_path, monkeypatch):
     monkeypatch.setattr("cited_cli.commands.job.watch_job", _fast_watch)
 
     # ── Register all API mocks ────────────────────────────────────────────────
-    respx.post(f"{DEV_API}/businesses").mock(
-        return_value=httpx.Response(201, json=MOCK_BUSINESS)
-    )
-    respx.post(f"{DEV_API}/named-audits").mock(
-        return_value=httpx.Response(201, json=MOCK_TEMPLATE)
-    )
+    respx.post(f"{DEV_API}/businesses").mock(return_value=httpx.Response(201, json=MOCK_BUSINESS))
+    respx.post(f"{DEV_API}/named-audits").mock(return_value=httpx.Response(201, json=MOCK_TEMPLATE))
     respx.put(f"{DEV_API}/named-audits/{TEMPLATE_ID}").mock(
         return_value=httpx.Response(200, json=MOCK_TEMPLATE_UPDATED)
     )
@@ -1218,27 +1532,53 @@ def test_full_pipeline(runner, cli_app, tmp_path, monkeypatch):
     )
 
     # ── Step 1: Create a business ─────────────────────────────────────────────
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "--json", "business", "create",
-        "--name", "Acme GEO Corp",
-        "--website", "https://acme.example.com",
-        "--description", "Acme makes AI-powered tools for enterprise teams with great GEO presence.",
-        "--industry", "SaaS",
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "business",
+            "create",
+            "--name",
+            "Acme GEO Corp",
+            "--website",
+            "https://acme.example.com",
+            "--description",
+            "Acme makes AI-powered tools for enterprise teams with great GEO presence.",
+            "--industry",
+            "SaaS",
+        ],
+    )
     business = json.loads(result.output)
     business_id = business["id"]  # ← threading state into next step
 
     assert business_id == BUSINESS_ID
 
     # ── Step 2: Create an audit template ─────────────────────────────────────
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "--json", "audit", "template", "create",
-        "--name", "Q4 GEO Audit",
-        "--business", business_id,  # ← uses business_id from step 1
-        "--description", "Checks citation presence across key GEO keywords",
-        "--question", "Are you cited when people ask about AI tools?",
-        "--question", "Does your product appear for enterprise GEO searches?",
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "audit",
+            "template",
+            "create",
+            "--name",
+            "Q4 GEO Audit",
+            "--business",
+            business_id,  # ← uses business_id from step 1
+            "--description",
+            "Checks citation presence across key GEO keywords",
+            "--question",
+            "Are you cited when people ask about AI tools?",
+            "--question",
+            "Does your product appear for enterprise GEO searches?",
+        ],
+    )
     template = json.loads(result.output)
     template_id = template["id"]  # ← threading state into next step
 
@@ -1247,25 +1587,47 @@ def test_full_pipeline(runner, cli_app, tmp_path, monkeypatch):
 
     # ── Step 2b: Refine the template questions ──────────────────────────────
     # Auto-generated questions are rarely perfect — update before running audit
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "--json", "audit", "template", "update",
-        template_id,
-        "--name", "Q4 GEO Audit Revised",
-        "--question", "Are we cited for AI safety research?",
-        "--question", "Do enterprise buyers find us via AI assistants?",
-        "--question", "Are we mentioned in responsible AI discussions?",
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "audit",
+            "template",
+            "update",
+            template_id,
+            "--name",
+            "Q4 GEO Audit Revised",
+            "--question",
+            "Are we cited for AI safety research?",
+            "--question",
+            "Do enterprise buyers find us via AI assistants?",
+            "--question",
+            "Are we mentioned in responsible AI discussions?",
+        ],
+    )
     updated = json.loads(result.output)
     assert updated["id"] == template_id
     assert len(updated["questions"]) == 3
     assert updated["name"] == "Q4 GEO Audit Revised"
 
     # ── Step 3: Start the audit ───────────────────────────────────────────────
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "--json", "audit", "start",
-        template_id,  # ← uses template_id from step 2
-        "--business", business_id,
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "audit",
+            "start",
+            template_id,  # ← uses template_id from step 2
+            "--business",
+            business_id,
+        ],
+    )
     audit_started = json.loads(result.output)
     audit_job_id = audit_started["job_id"]  # ← threading state into next step
 
@@ -1273,33 +1635,57 @@ def test_full_pipeline(runner, cli_app, tmp_path, monkeypatch):
     assert audit_started["status"] == "pending"
 
     # ── Step 4: Watch audit job until completion ──────────────────────────────
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "job", "watch",
-        audit_job_id,  # ← uses audit_job_id from step 3
-        "--type", "audit",
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "job",
+            "watch",
+            audit_job_id,  # ← uses audit_job_id from step 3
+            "--type",
+            "audit",
+        ],
+    )
     assert "completed" in result.output.lower()
 
     # ── Step 5: View audit results in CLI ─────────────────────────────────────
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "--json", "audit", "result",
-        audit_job_id,  # ← same audit_job_id
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "audit",
+            "result",
+            audit_job_id,  # ← same audit_job_id
+        ],
+    )
     audit_result = json.loads(result.output)
 
     assert audit_result["job_id"] == audit_job_id
     assert len(audit_result["questions"]) == 2
     # One question was cited, one was not
-    cited_questions    = [q for q in audit_result["questions"] if q["cited"]]
-    uncited_questions  = [q for q in audit_result["questions"] if not q["cited"]]
+    cited_questions = [q for q in audit_result["questions"] if q["cited"]]
+    uncited_questions = [q for q in audit_result["questions"] if not q["cited"]]
     assert len(cited_questions) == 1
     assert len(uncited_questions) == 1
 
     # ── Step 6: Scan/crawl the business ──────────────────────────────────────
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "--json", "business", "crawl",
-        business_id,  # ← uses business_id from step 1
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "business",
+            "crawl",
+            business_id,  # ← uses business_id from step 1
+        ],
+    )
     crawl = json.loads(result.output)
 
     assert crawl["status"] == "crawling"
@@ -1308,16 +1694,34 @@ def test_full_pipeline(runner, cli_app, tmp_path, monkeypatch):
     # Extract crawl job_id and watch it
     crawl_job_id = crawl.get("job_id", "")
     assert crawl_job_id == CRAWL_JOB_ID
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "job", "watch", crawl_job_id, "--type", "audit",
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "job",
+            "watch",
+            crawl_job_id,
+            "--type",
+            "audit",
+        ],
+    )
     assert "completed" in result.output.lower()
 
     # ── Step 7: View crawl results (health scores) in CLI ────────────────────
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "--json", "business", "health",
-        business_id,  # ← uses business_id from step 1
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "business",
+            "health",
+            business_id,  # ← uses business_id from step 1
+        ],
+    )
     health = json.loads(result.output)
 
     scores = health["scores"]
@@ -1328,10 +1732,18 @@ def test_full_pipeline(runner, cli_app, tmp_path, monkeypatch):
         assert value >= 0, f"{score_name} should be non-negative"
 
     # ── Step 8: Generate recommendations ─────────────────────────────────────
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "--json", "recommend", "start",
-        audit_job_id,  # ← uses audit_job_id from step 3
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "recommend",
+            "start",
+            audit_job_id,  # ← uses audit_job_id from step 3
+        ],
+    )
     recommend_started = json.loads(result.output)
     recommend_job_id = recommend_started["job_id"]  # ← threading state into next step
 
@@ -1339,18 +1751,34 @@ def test_full_pipeline(runner, cli_app, tmp_path, monkeypatch):
     assert recommend_started["audit_job_id"] == audit_job_id
 
     # ── Step 9: Watch recommendation job until completion ────────────────────
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "job", "watch",
-        recommend_job_id,  # ← uses recommend_job_id from step 8
-        "--type", "recommendations",
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "job",
+            "watch",
+            recommend_job_id,  # ← uses recommend_job_id from step 8
+            "--type",
+            "recommendations",
+        ],
+    )
     assert "completed" in result.output.lower()
 
     # ── Step 10: View insights — discover what to solve ──────────────────────
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "--json", "recommend", "insights",
-        recommend_job_id,  # ← uses recommend_job_id from step 8
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "recommend",
+            "insights",
+            recommend_job_id,  # ← uses recommend_job_id from step 8
+        ],
+    )
     insights = json.loads(result.output)
 
     # Extract the first question_insight source_id (what the user will pass to solution start)
@@ -1363,12 +1791,21 @@ def test_full_pipeline(runner, cli_app, tmp_path, monkeypatch):
 
     # ── Step 11: Start a solution for that insight ────────────────────────────
     # Run in human mode to verify the web nudge is printed
-    result = _invoke(runner, cli_app, [
-        "--env", "dev", "solution", "start",
-        recommend_job_id,          # ← uses recommend_job_id from step 8
-        "--type", "question_insight",
-        "--source", source_id,     # ← uses source_id from step 10
-    ])
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "solution",
+            "start",
+            recommend_job_id,  # ← uses recommend_job_id from step 8
+            "--type",
+            "question_insight",
+            "--source",
+            source_id,  # ← uses source_id from step 10
+        ],
+    )
 
     # Verify the job started
     assert "Solution Started" in result.output
@@ -1379,3 +1816,456 @@ def test_full_pipeline(runner, cli_app, tmp_path, monkeypatch):
 
     # Verify the watch hint is shown
     assert "cited job watch" in result.output
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# v0.4.0 / v0.5.0 HQ CRUD CLI commands — list/create/update/delete for
+# personas, products, buyer intents; profile-competitors list/set.
+#
+# These commands close the parity gap with the MCP tool surface. Tests use
+# the same pattern as the business/audit/recommend pipeline above: respx-mock
+# the backend endpoints, invoke via Typer CliRunner, assert on output + payload.
+# ═════════════════════════════════════════════════════════════════════════════
+
+
+PERSONA_ID = "p1a2c3d4-e5f6-7890-abcd-ef1234567892"
+PRODUCT_ID = "pr1a2c3d4-e5f6-7890-abcd-ef1234567893"
+INTENT_ID = "i1a2c3d4-e5f6-7890-abcd-ef1234567894"
+
+MOCK_PERSONA = {
+    "id": PERSONA_ID,
+    "name": "Mid-market RevOps lead",
+    "role": "Manager",
+    "description": "Owns rev-data tooling for a 200-person team.",
+}
+MOCK_PRODUCT = {
+    "id": PRODUCT_ID,
+    "name": "Acme Widget",
+    "category": "hardware",
+    "url": "https://acme.com/widget",
+}
+MOCK_INTENT = {
+    "id": INTENT_ID,
+    "question": "What's the cheapest acme widget?",
+    "intent_type": "informational",
+    "priority": "medium",
+    "is_answered": False,
+    "source": "manual",
+}
+MOCK_COMPETITORS = [
+    {"id": "c1", "name": "Rival One", "website": "https://rival1.com"},
+    {"id": "c2", "name": "Rival Two", "website": "https://rival2.com"},
+]
+
+
+# ─── Personas ────────────────────────────────────────────────────────────────
+
+
+@respx.mock
+def test_hq_persona_list(runner, cli_app, tmp_path, monkeypatch):
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.get(f"{DEV_API}/businesses/{BUSINESS_ID}/personas").mock(
+        return_value=httpx.Response(200, json=[MOCK_PERSONA])
+    )
+
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "hq",
+            BUSINESS_ID,
+            "persona",
+            "list",
+            BUSINESS_ID,
+        ],
+    )
+    data = json.loads(result.output)
+    assert data[0]["id"] == PERSONA_ID
+
+
+@respx.mock
+def test_hq_persona_create(runner, cli_app, tmp_path, monkeypatch):
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.post(f"{DEV_API}/businesses/{BUSINESS_ID}/personas").mock(
+        return_value=httpx.Response(201, json=MOCK_PERSONA)
+    )
+
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "hq",
+            BUSINESS_ID,
+            "persona",
+            "create",
+            BUSINESS_ID,
+            "--name",
+            "Mid-market RevOps lead",
+            "--description",
+            "Owns rev-data tooling for a 200-person team.",
+        ],
+    )
+    data = json.loads(result.output)
+    assert data["id"] == PERSONA_ID
+    # Verify payload — only declared fields are sent
+    sent = json.loads(respx.calls[0].request.content)
+    assert sent["name"] == "Mid-market RevOps lead"
+    assert sent["description"] == "Owns rev-data tooling for a 200-person team."
+
+
+@respx.mock
+def test_hq_persona_update_partial(runner, cli_app, tmp_path, monkeypatch):
+    """Update with only --name should send a PATCH with only name in the payload."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.patch(f"{DEV_API}/businesses/{BUSINESS_ID}/personas/{PERSONA_ID}").mock(
+        return_value=httpx.Response(200, json={**MOCK_PERSONA, "name": "Renamed"})
+    )
+
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "hq",
+            BUSINESS_ID,
+            "persona",
+            "update",
+            BUSINESS_ID,
+            PERSONA_ID,
+            "--name",
+            "Renamed",
+        ],
+    )
+    data = json.loads(result.output)
+    assert data["name"] == "Renamed"
+    # Confirm partial-update — payload only has the supplied field
+    sent = json.loads(respx.calls[0].request.content)
+    assert sent == {"name": "Renamed"}
+
+
+def test_hq_persona_delete_skips_prompt_with_flag(runner, cli_app, tmp_path, monkeypatch):
+    _setup_logged_in(tmp_path, monkeypatch)
+    with respx.mock:
+        respx.delete(f"{DEV_API}/businesses/{BUSINESS_ID}/personas/{PERSONA_ID}").mock(
+            return_value=httpx.Response(204)
+        )
+
+        result = runner.invoke(
+            cli_app,
+            [
+                "--env",
+                "dev",
+                "hq",
+                BUSINESS_ID,
+                "persona",
+                "delete",
+                BUSINESS_ID,
+                PERSONA_ID,
+                "--yes",
+            ],
+        )
+    assert result.exit_code == 0
+    assert "Deleted persona" in result.output
+
+
+# ─── Products ────────────────────────────────────────────────────────────────
+
+
+@respx.mock
+def test_hq_product_list(runner, cli_app, tmp_path, monkeypatch):
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.get(f"{DEV_API}/businesses/{BUSINESS_ID}/products").mock(
+        return_value=httpx.Response(200, json=[MOCK_PRODUCT])
+    )
+
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "hq",
+            BUSINESS_ID,
+            "product",
+            "list",
+            BUSINESS_ID,
+        ],
+    )
+    data = json.loads(result.output)
+    assert data[0]["id"] == PRODUCT_ID
+    assert data[0]["category"] == "hardware"
+
+
+@respx.mock
+def test_hq_product_create(runner, cli_app, tmp_path, monkeypatch):
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.post(f"{DEV_API}/businesses/{BUSINESS_ID}/products").mock(
+        return_value=httpx.Response(201, json=MOCK_PRODUCT)
+    )
+
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "hq",
+            BUSINESS_ID,
+            "product",
+            "create",
+            BUSINESS_ID,
+            "--name",
+            "Acme Widget",
+            "--category",
+            "hardware",
+            "--url",
+            "https://acme.com/widget",
+        ],
+    )
+    data = json.loads(result.output)
+    assert data["id"] == PRODUCT_ID
+    sent = json.loads(respx.calls[0].request.content)
+    assert sent["category"] == "hardware"
+    assert sent["url"] == "https://acme.com/widget"
+
+
+@respx.mock
+def test_hq_product_update_uses_patch(runner, cli_app, tmp_path, monkeypatch):
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.patch(f"{DEV_API}/businesses/{BUSINESS_ID}/products/{PRODUCT_ID}").mock(
+        return_value=httpx.Response(200, json={**MOCK_PRODUCT, "name": "Renamed"})
+    )
+
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "hq",
+            BUSINESS_ID,
+            "product",
+            "update",
+            BUSINESS_ID,
+            PRODUCT_ID,
+            "--name",
+            "Renamed",
+        ],
+    )
+    data = json.loads(result.output)
+    assert data["name"] == "Renamed"
+    assert respx.calls[0].request.method == "PATCH"
+
+
+def test_hq_product_delete_with_yes(runner, cli_app, tmp_path, monkeypatch):
+    _setup_logged_in(tmp_path, monkeypatch)
+    with respx.mock:
+        respx.delete(f"{DEV_API}/businesses/{BUSINESS_ID}/products/{PRODUCT_ID}").mock(
+            return_value=httpx.Response(204)
+        )
+
+        result = runner.invoke(
+            cli_app,
+            [
+                "--env",
+                "dev",
+                "hq",
+                BUSINESS_ID,
+                "product",
+                "delete",
+                BUSINESS_ID,
+                PRODUCT_ID,
+                "--yes",
+            ],
+        )
+    assert result.exit_code == 0
+
+
+# ─── Buyer intents (v0.5.0 added update + delete) ────────────────────────────
+
+
+@respx.mock
+def test_hq_intent_list(runner, cli_app, tmp_path, monkeypatch):
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.get(f"{DEV_API}/businesses/{BUSINESS_ID}/buyer-intents").mock(
+        return_value=httpx.Response(200, json=[MOCK_INTENT])
+    )
+
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "hq",
+            BUSINESS_ID,
+            "intent",
+            "list",
+            BUSINESS_ID,
+        ],
+    )
+    data = json.loads(result.output)
+    assert data[0]["id"] == INTENT_ID
+
+
+@respx.mock
+def test_hq_intent_create(runner, cli_app, tmp_path, monkeypatch):
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.post(f"{DEV_API}/businesses/{BUSINESS_ID}/buyer-intents").mock(
+        return_value=httpx.Response(201, json=MOCK_INTENT)
+    )
+
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "hq",
+            BUSINESS_ID,
+            "intent",
+            "create",
+            BUSINESS_ID,
+            "--intent",
+            "What's the cheapest acme widget?",
+            "--description",
+            "Pricing-sensitive shoppers",
+        ],
+    )
+    data = json.loads(result.output)
+    assert data["id"] == INTENT_ID
+
+
+@respx.mock
+def test_hq_intent_update_partial(runner, cli_app, tmp_path, monkeypatch):
+    """v0.5.0: update_buyer_intent — partial PATCH against /buyer-intents/{id}."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.patch(f"{DEV_API}/businesses/{BUSINESS_ID}/buyer-intents/{INTENT_ID}").mock(
+        return_value=httpx.Response(
+            200, json={**MOCK_INTENT, "priority": "high", "is_answered": True}
+        )
+    )
+
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "hq",
+            BUSINESS_ID,
+            "intent",
+            "update",
+            BUSINESS_ID,
+            INTENT_ID,
+            "--priority",
+            "high",
+            "--is-answered",
+        ],
+    )
+    data = json.loads(result.output)
+    assert data["priority"] == "high"
+    assert data["is_answered"] is True
+    sent = json.loads(respx.calls[0].request.content)
+    # Only the supplied fields land in the PATCH body
+    assert sent == {"priority": "high", "is_answered": True}
+    assert respx.calls[0].request.method == "PATCH"
+
+
+def test_hq_intent_delete_with_yes(runner, cli_app, tmp_path, monkeypatch):
+    """v0.5.0: delete_buyer_intent — DELETE against the singular endpoint."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    with respx.mock:
+        respx.delete(f"{DEV_API}/businesses/{BUSINESS_ID}/buyer-intents/{INTENT_ID}").mock(
+            return_value=httpx.Response(204)
+        )
+
+        result = runner.invoke(
+            cli_app,
+            [
+                "--env",
+                "dev",
+                "hq",
+                BUSINESS_ID,
+                "intent",
+                "delete",
+                BUSINESS_ID,
+                INTENT_ID,
+                "--yes",
+            ],
+        )
+    assert result.exit_code == 0
+    assert "Deleted buyer intent" in result.output
+
+
+# ─── Profile competitors ─────────────────────────────────────────────────────
+
+
+@respx.mock
+def test_business_profile_competitors_list(runner, cli_app, tmp_path, monkeypatch):
+    _setup_logged_in(tmp_path, monkeypatch)
+    respx.get(f"{DEV_API}/businesses/{BUSINESS_ID}/profile-competitors").mock(
+        return_value=httpx.Response(200, json=MOCK_COMPETITORS)
+    )
+
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "business",
+            "profile-competitors",
+            "list",
+            BUSINESS_ID,
+        ],
+    )
+    data = json.loads(result.output)
+    assert len(data) == 2
+    assert data[0]["name"] == "Rival One"
+
+
+@respx.mock
+def test_business_profile_competitors_set_replaces(runner, cli_app, tmp_path, monkeypatch):
+    """set is REPLACE semantics — pass the whole desired list, backend returns
+    the new state."""
+    _setup_logged_in(tmp_path, monkeypatch)
+    new_state = [{"id": "c3", "name": "Acme", "website": "https://acme.com"}]
+    respx.put(f"{DEV_API}/businesses/{BUSINESS_ID}/profile-competitors").mock(
+        return_value=httpx.Response(200, json=new_state)
+    )
+
+    result = _invoke(
+        runner,
+        cli_app,
+        [
+            "--env",
+            "dev",
+            "--json",
+            "business",
+            "profile-competitors",
+            "set",
+            BUSINESS_ID,
+            "--competitor",
+            "Acme|https://acme.com",
+        ],
+    )
+    data = json.loads(result.output)
+    assert data[0]["name"] == "Acme"
+    sent = json.loads(respx.calls[0].request.content)
+    assert sent == {"competitors": [{"name": "Acme", "website": "https://acme.com"}]}


### PR DESCRIPTION
Closes the test-coverage gap surfaced after the v0.5.0 release. Before this PR, 13 of the new CRUD tools had only registry-membership references — no unit tests asserting request shape, HTTP method, or error handling.

## What's added

**P0 — unit tests for the 13 undertested CRUD tools (~40 tests in `test_tools.py`)**
- `TestProfileCompetitorsTools` — list/set with REPLACE semantics + max-10 cap
- `TestPersonaTools` / `TestProductTools` / `TestBuyerIntentTools` — list/create/update/delete chains
- `TestBusinessWriteErrorHandling` — 404/422/403 paths for `update_business` + `delete_business`

Each tool: happy-path (HTTP method + payload shape) + unauth. Update/delete tools additionally test the "at least one field required" guard. Buyer-intent update specifically verifies PATCH against `/buyer-intents/{intent_id}` (the v0.5.0 endpoint).

**P1 — per-tool tier assertions in `test_plan_gating.py` (+22 assertions)**
The bulk-count test only catches gross deletions. These explicit per-tool assertions catch tier-misclassification (e.g., a Scale tool slipping to free → silent revenue loss).

**P1 — CLI integration tests in `test_pipeline.py` (+14 tests)**
Mocked-HTTP CliRunner tests for `hq <biz> persona/product/intent` (list/create/update/delete) and `business profile-competitors` (list/set). Verifies partial-update PATCH semantics end-to-end through the CLI.

**P2 — new `test_surface_invariants.py` (7 tests)**
Lock-down tests that catch surface changes that should be deliberate:
- Registered tool name set snapshot (73 names)
- Per-tool tier assignments snapshot (18 gated tools)
- Top changelog entry's fingerprint matches live registry's `compute_tools_fingerprint()`
- No `fingerprint: "PENDING"` entries on main
- README.md + SKILL.md cite a tool count that matches the live registry (caught real doc drift!)
- `whats_new` returns v0.5.0 entries given a v0.4.0 cached fingerprint

**P3 — README.md + SKILL.md tool-count refresh**
Caught by the new doc-count tests. Updated tier breakdowns from stale `22/38/56` (README) and `19/32/42` (SKILL) to current `31/62/73`.

## Tests

**383 passed, 1 skipped** (was 300 — 83 new tests).

```
packages/mcp/tests/test_tools.py             165 → 206  (+41)
packages/mcp/tests/test_plan_gating.py        28 → 50   (+22)
packages/mcp/tests/test_surface_invariants.py  0 →  7   (+7, new file)
tests/test_pipeline.py                        45 → 59   (+14)
```

## Test plan

- [ ] CI green (lint + format + tests across Python 3.11/3.12/3.13)
- [ ] If you intentionally add/remove a tool, the snapshot test will fail with a clear "missing from registry" / "registered without being in snapshot" message — update `EXPECTED_TOOLS_V0_5_0` and the changelog top entry in the same commit
- [ ] If you change a tool's tier, `test_per_tool_tier_assignments_stable` will tell you which tool drifted

🤖 Generated with [Claude Code](https://claude.com/claude-code)